### PR TITLE
[TECH] Forcer des versions spécifiques de dépendances

### DIFF
--- a/pubspec.lock
+++ b/pubspec.lock
@@ -14,7 +14,7 @@ packages:
       name: async
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.8.1"
+    version: "2.6.1"
   boolean_selector:
     dependency: transitive
     description:
@@ -35,7 +35,7 @@ packages:
       name: charcode
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.3.1"
+    version: "1.2.0"
   clock:
     dependency: transitive
     description:
@@ -56,14 +56,14 @@ packages:
       name: cloud_firestore_platform_interface
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "5.4.1"
+    version: "5.4.2"
   cloud_firestore_web:
     dependency: transitive
     description:
       name: cloud_firestore_web
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.4.2"
+    version: "2.4.3"
   collection:
     dependency: "direct main"
     description:
@@ -154,14 +154,14 @@ packages:
       name: firebase_core_platform_interface
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "4.0.1"
+    version: "4.1.0"
   firebase_core_web:
     dependency: transitive
     description:
       name: firebase_core_web
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.1.0"
+    version: "1.2.0"
   firebase_crashlytics:
     dependency: "direct main"
     description:
@@ -175,7 +175,7 @@ packages:
       name: firebase_crashlytics_platform_interface
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "3.1.2"
+    version: "3.1.3"
   firebase_messaging:
     dependency: "direct main"
     description:
@@ -210,7 +210,7 @@ packages:
       name: firebase_remote_config_platform_interface
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.3.0+5"
+    version: "0.3.0+6"
   flutter:
     dependency: "direct main"
     description: flutter
@@ -309,7 +309,7 @@ packages:
       name: meta
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.7.0"
+    version: "1.3.0"
   package_info:
     dependency: "direct main"
     description:
@@ -330,7 +330,7 @@ packages:
       name: path_drawing
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.5.1"
+    version: "0.5.1+1"
   path_parsing:
     dependency: transitive
     description:
@@ -400,7 +400,7 @@ packages:
       name: plugin_platform_interface
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.0.1"
+    version: "2.0.2"
   process:
     dependency: transitive
     description:
@@ -503,7 +503,7 @@ packages:
       name: test_api
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.4.2"
+    version: "0.3.0"
   timezone:
     dependency: transitive
     description:
@@ -531,7 +531,7 @@ packages:
       name: win32
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.2.9"
+    version: "2.2.10"
   xdg_directories:
     dependency: transitive
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -11,25 +11,25 @@ dependencies:
   # Flutter
   flutter:
     sdk: flutter
-  shared_preferences: ^2.0.6
-  flutter_svg: ^0.22.0
-  flutter_redux: ^0.8.2
-  package_info: ^2.0.2
-  flutter_local_notifications: ^9.0.0
+  shared_preferences: 2.0.7
+  flutter_svg: 0.22.0
+  flutter_redux: 0.8.2
+  package_info: 2.0.2
+  flutter_local_notifications: 9.0.0
   # Dart
-  http: ^0.13.3
-  intl: ^0.17.0
-  collection: ^1.15.0
+  http: 0.13.3
+  intl: 0.17.0
+  collection: 1.15.0
   equatable: 2.0.3
   # Firebase
-  firebase_core: ^1.6.0
-  firebase_crashlytics: ^2.2.1
-  firebase_remote_config: ^0.10.0+5
-  firebase_analytics: ^8.3.2
-  firebase_messaging: ^10.0.8
-  cloud_firestore: ^2.5.1
+  firebase_core: 1.7.0
+  firebase_crashlytics: 2.2.1
+  firebase_remote_config: 0.10.0+5
+  firebase_analytics: 8.3.2
+  firebase_messaging: 10.0.8
+  cloud_firestore: 2.5.3
   # UI
-  google_fonts: ^2.1.0
+  google_fonts: 2.1.0
 
 dev_dependencies:
   flutter_test:


### PR DESCRIPTION
C'est notamment pour éviter d'avoir des diff dans le fichier `pubspec.lock`. Après, je ne sais pas pourquoi chez moi ça a descendu la version de 2 dépendances sur ce fichiers… Peut-être n'a t'on pas tous les 3 la même versiond de FLutter sur nos postes ? Perso j'ai la 2.2.3…