### PR TITLE
[TECH] 95 - Forcer une version de Flutter plus spécifique

### DIFF
--- a/.github/workflows/github-actions.yml
+++ b/.github/workflows/github-actions.yml
@@ -16,5 +16,5 @@ jobs:
           java-version: '12.x'
       - uses: subosito/flutter-action@v1
         with:
-          flutter-version: '2.2.0'
+          flutter-version: '2.5.3'
       - run: flutter test

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -624,5 +624,5 @@ packages:
     source: hosted
     version: "5.1.2"
 sdks:
-  dart: ">=2.13.0 <3.0.0"
-  flutter: ">=2.2.0"
+  dart: "2.14.4"
+  flutter: ">=2.5.3"

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -5,7 +5,8 @@ publish_to: 'none'
 version: 0.6.0+26
 
 environment:
-  sdk: ">=2.12.0 <3.0.0"
+  sdk: "2.14.4" # Dart version
+  flutter: 2.5.3
 
 dependencies:
   # Flutter


### PR DESCRIPTION
Comme mentionné [ici](https://github.com/flutter/flutter/issues/29211),  ça ne semble pas possible. Pour autant, en figeant une version minimum, on est peut être un peu moins freestyle qu'actuellement…

A discuter.