### PR TITLE
[TECH] add debounce to autocomplete

### DIFF
--- a/lib/utils/debouncer.dart
+++ b/lib/utils/debouncer.dart
@@ -1,0 +1,14 @@
+import 'dart:async';
+
+class Debouncer {
+  final Duration duration;
+
+  Timer? _timer;
+
+  Debouncer({required this.duration});
+
+  void run(void Function() action) {
+    _timer?.cancel();
+    _timer = Timer(duration, action);
+  }
+}

--- a/lib/widgets/location_autocomplete.dart
+++ b/lib/widgets/location_autocomplete.dart
@@ -5,6 +5,7 @@ import 'package:pass_emploi_app/presentation/location_view_model.dart';
 import 'package:pass_emploi_app/ui/app_colors.dart';
 import 'package:pass_emploi_app/ui/text_styles.dart';
 import 'package:pass_emploi_app/utils/keyboard.dart';
+import 'package:pass_emploi_app/utils/debouncer.dart';
 
 const int _fakeItemsAddedToLeverageAdditionalScrollInAutocomplete = 20;
 
@@ -14,6 +15,8 @@ class LocationAutocomplete extends StatelessWidget {
   final String? Function() getPreviouslySelectedTitle;
   final List<LocationViewModel> locationViewModels;
   final String hint;
+
+  final Debouncer _debouncer = Debouncer(duration: Duration(milliseconds: 200));
 
   LocationAutocomplete({
     required this.onInputLocation,
@@ -28,9 +31,11 @@ class LocationAutocomplete extends StatelessWidget {
     return LayoutBuilder(
       builder: (context, constraints) => Autocomplete<LocationViewModel>(
         optionsBuilder: (textEditingValue) {
-          final newLocationQuery = textEditingValue.text;
-          _deleteSelectedLocationOnTextDeletion(newLocationQuery);
-          onInputLocation(newLocationQuery);
+          _debouncer.run(() {
+            final newLocationQuery = textEditingValue.text;
+            _deleteSelectedLocationOnTextDeletion(newLocationQuery);
+            onInputLocation(newLocationQuery);
+          });
           return [_fakeLocationRequiredByAutocompleteToCallOptionsViewBuilderMethod()];
         },
         onSelected: (locationViewModel) {


### PR DESCRIPTION
Une petite proposition, permet d'éviter un bug sur l'autocomplétion, par exemple lorsqu'on efface tout très vite, les résultats d'une requête peuvent arriver alors que le champ est vide.

Avec le debounce on attend 200ms avant d'envoyer la requête.