### PR TITLE
Feat/ US-191 magic api for user actions tracking

### DIFF
--- a/lib/analytics/analytics_constants.dart
+++ b/lib/analytics/analytics_constants.dart
@@ -33,4 +33,5 @@ class AnalyticsActionNames {
   static const offreEmploiAddFavori = "solutions/emploi/detail?favori=true";
   static const offreEmploiRemoveFavori = "solutions/emploi/detail?favori=false";
 
+  static const deleteUserAction = "actions/list?deleteSuccess=true";
 }

--- a/lib/auth/auth_id_token.dart
+++ b/lib/auth/auth_id_token.dart
@@ -4,17 +4,21 @@ import 'package:equatable/equatable.dart';
 
 const int _additionalExpirationSecurityIsSeconds = 15;
 
+enum LoginStructure { MILO, POLE_EMPLOI, PASS_EMPLOI }
+
 class AuthIdToken extends Equatable {
   final String userId;
   final String firstName;
   final String lastName;
   final int expiresAt;
+  final String loginStructure;
 
   AuthIdToken({
     required this.userId,
     required this.firstName,
     required this.lastName,
     required this.expiresAt,
+    required this.loginStructure,
   });
 
   factory AuthIdToken.parse(String idToken) {
@@ -35,6 +39,7 @@ class AuthIdToken extends Equatable {
       firstName: json["given_name"],
       lastName: json["family_name"],
       expiresAt: json["exp"] as int,
+      loginStructure: json["userStructure"],
     );
   }
 
@@ -42,4 +47,14 @@ class AuthIdToken extends Equatable {
 
   @override
   List<Object?> get props => [userId, firstName, lastName, expiresAt];
+
+  LoginStructure getLoginMode() {
+    if (loginStructure == "MILO") {
+      return LoginStructure.MILO;
+    } else if (loginStructure == "POLE_EMPLOI") {
+      return LoginStructure.POLE_EMPLOI;
+    } else {
+      return LoginStructure.PASS_EMPLOI;
+    }
+  }
 }

--- a/lib/auth/auth_id_token.dart
+++ b/lib/auth/auth_id_token.dart
@@ -4,21 +4,21 @@ import 'package:equatable/equatable.dart';
 
 const int _additionalExpirationSecurityIsSeconds = 15;
 
-enum LoginStructure { MILO, POLE_EMPLOI, PASS_EMPLOI }
+enum LoginMode { MILO, POLE_EMPLOI, PASS_EMPLOI }
 
 class AuthIdToken extends Equatable {
   final String userId;
   final String firstName;
   final String lastName;
   final int expiresAt;
-  final String loginStructure;
+  final String loginMode;
 
   AuthIdToken({
     required this.userId,
     required this.firstName,
     required this.lastName,
     required this.expiresAt,
-    required this.loginStructure,
+    required this.loginMode,
   });
 
   factory AuthIdToken.parse(String idToken) {
@@ -39,7 +39,7 @@ class AuthIdToken extends Equatable {
       firstName: json["given_name"],
       lastName: json["family_name"],
       expiresAt: json["exp"] as int,
-      loginStructure: json["userStructure"],
+      loginMode: json["userStructure"],
     );
   }
 
@@ -48,13 +48,13 @@ class AuthIdToken extends Equatable {
   @override
   List<Object?> get props => [userId, firstName, lastName, expiresAt];
 
-  LoginStructure getLoginMode() {
-    if (loginStructure == "MILO") {
-      return LoginStructure.MILO;
-    } else if (loginStructure == "POLE_EMPLOI") {
-      return LoginStructure.POLE_EMPLOI;
+  LoginMode getLoginMode() {
+    if (loginMode == "MILO") {
+      return LoginMode.MILO;
+    } else if (loginMode == "POLE_EMPLOI") {
+      return LoginMode.POLE_EMPLOI;
     } else {
-      return LoginStructure.PASS_EMPLOI;
+      return LoginMode.PASS_EMPLOI;
     }
   }
 }

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -30,6 +30,7 @@ import 'package:pass_emploi_app/redux/states/app_state.dart';
 import 'package:pass_emploi_app/redux/store/store_factory.dart';
 import 'package:pass_emploi_app/repositories/chat_repository.dart';
 import 'package:pass_emploi_app/repositories/crypto/chat_crypto.dart';
+import 'package:pass_emploi_app/repositories/event_tracker_repository.dart';
 import 'package:pass_emploi_app/repositories/firebase_auth_repository.dart';
 import 'package:pass_emploi_app/repositories/immersion_details_repository.dart';
 import 'package:pass_emploi_app/repositories/immersion_repository.dart';
@@ -139,6 +140,7 @@ Future<Store<AppState>> _initializeReduxStore(Configuration configuration,
     FirebaseAuthRepository(configuration.serverBaseUrl, httpClient, headersBuilder, crashlytics),
     FirebaseAuthWrapper(),
     chatCrypto,
+    EventTrackerRepository(configuration.serverBaseUrl, httpClient, headersBuilder, crashlytics),
   ).initializeReduxStore(initialState: AppState.initialState());
   accessTokenRetriever.setStore(reduxStore);
   return reduxStore;

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -30,7 +30,7 @@ import 'package:pass_emploi_app/redux/states/app_state.dart';
 import 'package:pass_emploi_app/redux/store/store_factory.dart';
 import 'package:pass_emploi_app/repositories/chat_repository.dart';
 import 'package:pass_emploi_app/repositories/crypto/chat_crypto.dart';
-import 'package:pass_emploi_app/repositories/event_tracker_repository.dart';
+import 'package:pass_emploi_app/repositories/tracking_analytics/tracking_event_repository.dart';
 import 'package:pass_emploi_app/repositories/firebase_auth_repository.dart';
 import 'package:pass_emploi_app/repositories/immersion_details_repository.dart';
 import 'package:pass_emploi_app/repositories/immersion_repository.dart';
@@ -140,7 +140,7 @@ Future<Store<AppState>> _initializeReduxStore(Configuration configuration,
     FirebaseAuthRepository(configuration.serverBaseUrl, httpClient, headersBuilder, crashlytics),
     FirebaseAuthWrapper(),
     chatCrypto,
-    EventTrackerRepository(configuration.serverBaseUrl, httpClient, headersBuilder, crashlytics),
+    TrackingEventRepository(configuration.serverBaseUrl, httpClient, headersBuilder, crashlytics),
   ).initializeReduxStore(initialState: AppState.initialState());
   accessTokenRetriever.setStore(reduxStore);
   return reduxStore;

--- a/lib/models/user.dart
+++ b/lib/models/user.dart
@@ -1,12 +1,14 @@
 import 'package:equatable/equatable.dart';
+import 'package:pass_emploi_app/auth/auth_id_token.dart';
 
 class User extends Equatable {
   final String id;
   final String firstName;
   final String lastName;
+  final LoginStructure loginMode;
 
-  User({required this.id, required this.firstName, required this.lastName});
+  User({required this.id, required this.firstName, required this.lastName, required this.loginMode});
 
   @override
-  List<Object?> get props => [id, firstName, lastName];
+  List<Object?> get props => [id, firstName, lastName, loginMode];
 }

--- a/lib/models/user.dart
+++ b/lib/models/user.dart
@@ -5,7 +5,7 @@ class User extends Equatable {
   final String id;
   final String firstName;
   final String lastName;
-  final LoginStructure loginMode;
+  final LoginMode loginMode;
 
   User({required this.id, required this.firstName, required this.lastName, required this.loginMode});
 

--- a/lib/network/post_tracking_event_request.dart
+++ b/lib/network/post_tracking_event_request.dart
@@ -1,12 +1,11 @@
+import 'package:pass_emploi_app/auth/auth_id_token.dart';
 import 'package:pass_emploi_app/network/json_serializable.dart';
 
 enum EventType { MESSAGE_ENVOYE, OFFRE_POSTULEE, OFFRE_PARTAGEE }
 
-enum StructureType { MILO, POLE_EMPLOI, PASSS_EMPLOI }
-
 class Emetteur extends JsonSerializable {
   final String id;
-  final StructureType structure;
+  final LoginStructure structure;
 
   Emetteur({required this.id, required this.structure});
 
@@ -17,21 +16,21 @@ class Emetteur extends JsonSerializable {
         "id": id,
       };
 
-  String _toString(StructureType structure) {
+  String _toString(LoginStructure structure) {
     switch (structure) {
-      case StructureType.MILO:
+      case LoginStructure.MILO:
         return "MILO";
-      case StructureType.POLE_EMPLOI:
+      case LoginStructure.POLE_EMPLOI:
         return "POLE_EMPLOI";
-      case StructureType.PASSS_EMPLOI:
-        return "PASSS_EMPLOI";
+      case LoginStructure.PASS_EMPLOI:
+        return "PASS_EMPLOI";
     }
   }
 }
 
 class PostTrackingEvent extends JsonSerializable {
   final EventType event;
-  final StructureType structure;
+  final LoginStructure structure;
   final String id;
 
   PostTrackingEvent({required this.event, required this.structure, required this.id});

--- a/lib/network/post_tracking_event_request.dart
+++ b/lib/network/post_tracking_event_request.dart
@@ -3,26 +3,26 @@ import 'package:pass_emploi_app/network/json_serializable.dart';
 
 enum EventType { MESSAGE_ENVOYE, OFFRE_POSTULEE, OFFRE_PARTAGEE }
 
-class Emetteur extends JsonSerializable {
+class PostTrackingEmetteur extends JsonSerializable {
   final String id;
-  final LoginStructure structure;
+  final LoginMode loginMode;
 
-  Emetteur({required this.id, required this.structure});
+  PostTrackingEmetteur({required this.id, required this.loginMode});
 
   @override
   Map<String, dynamic> toJson() => {
         "type": "JEUNE",
-        "structure": _toString(structure),
+        "structure": _toString(loginMode),
         "id": id,
       };
 
-  String _toString(LoginStructure structure) {
+  String _toString(LoginMode structure) {
     switch (structure) {
-      case LoginStructure.MILO:
+      case LoginMode.MILO:
         return "MILO";
-      case LoginStructure.POLE_EMPLOI:
+      case LoginMode.POLE_EMPLOI:
         return "POLE_EMPLOI";
-      case LoginStructure.PASS_EMPLOI:
+      case LoginMode.PASS_EMPLOI:
         return "PASS_EMPLOI";
     }
   }
@@ -30,15 +30,15 @@ class Emetteur extends JsonSerializable {
 
 class PostTrackingEvent extends JsonSerializable {
   final EventType event;
-  final LoginStructure structure;
+  final LoginMode loginMode;
   final String id;
 
-  PostTrackingEvent({required this.event, required this.structure, required this.id});
+  PostTrackingEvent({required this.event, required this.loginMode, required this.id});
 
   @override
   Map<String, dynamic> toJson() => {
         "type": _toString(event),
-        "emetteur": Emetteur(id: id, structure: structure).toJson(),
+        "emetteur": PostTrackingEmetteur(id: id, loginMode: loginMode).toJson(),
       };
 
   _toString(EventType event) {

--- a/lib/network/post_tracking_event_request.dart
+++ b/lib/network/post_tracking_event_request.dart
@@ -1,0 +1,55 @@
+import 'package:pass_emploi_app/network/json_serializable.dart';
+
+enum EventType { MESSAGE_ENVOYE, OFFRE_POSTULEE, OFFRE_PARTAGEE }
+
+enum StructureType { MILO, POLE_EMPLOI, PASSS_EMPLOI }
+
+class Emetteur extends JsonSerializable {
+  final String id;
+  final StructureType structure;
+
+  Emetteur({required this.id, required this.structure});
+
+  @override
+  Map<String, dynamic> toJson() => {
+        "type": "JEUNE",
+        "structure": _toString(structure),
+        "id": id,
+      };
+
+  String _toString(StructureType structure) {
+    switch (structure) {
+      case StructureType.MILO:
+        return "MILO";
+      case StructureType.POLE_EMPLOI:
+        return "POLE_EMPLOI";
+      case StructureType.PASSS_EMPLOI:
+        return "PASSS_EMPLOI";
+    }
+  }
+}
+
+class PostTrackingEvent extends JsonSerializable {
+  final EventType event;
+  final StructureType structure;
+  final String id;
+
+  PostTrackingEvent({required this.event, required this.structure, required this.id});
+
+  @override
+  Map<String, dynamic> toJson() => {
+        "type": _toString(event),
+        "emetteur": Emetteur(id: id, structure: structure).toJson(),
+      };
+
+  _toString(EventType event) {
+    switch (event) {
+      case EventType.MESSAGE_ENVOYE:
+        return "MESSAGE_ENVOYE";
+      case EventType.OFFRE_POSTULEE:
+        return "OFFRE_POSTULEE";
+      case EventType.OFFRE_PARTAGEE:
+        return "OFFRE_PARTAGEE";
+    }
+  }
+}

--- a/lib/pages/chat_page.dart
+++ b/lib/pages/chat_page.dart
@@ -3,10 +3,12 @@ import 'package:flutter_redux/flutter_redux.dart';
 import 'package:flutter_svg/svg.dart';
 import 'package:matomo/matomo.dart';
 import 'package:pass_emploi_app/analytics/analytics_constants.dart';
+import 'package:pass_emploi_app/network/post_tracking_event_request.dart';
 import 'package:pass_emploi_app/presentation/chat_item.dart';
 import 'package:pass_emploi_app/presentation/chat_page_view_model.dart';
 import 'package:pass_emploi_app/presentation/display_state.dart';
 import 'package:pass_emploi_app/redux/actions/chat_actions.dart';
+import 'package:pass_emploi_app/redux/actions/tracking_event_action.dart';
 import 'package:pass_emploi_app/redux/states/app_state.dart';
 import 'package:pass_emploi_app/ui/app_colors.dart';
 import 'package:pass_emploi_app/ui/drawables.dart';
@@ -150,6 +152,8 @@ class _ChatPageState extends State<ChatPage> with WidgetsBindingObserver {
                     if (_controller.value.text.isNotEmpty) {
                       viewModel.onSendMessage(_controller.value.text);
                       _controller.clear();
+                      StoreProvider.of<AppState>(context)
+                          .dispatch(RequestTrackingEventAction(EventType.MESSAGE_ENVOYE));
                     }
                   },
                 ),

--- a/lib/pages/offre_emploi_details_page.dart
+++ b/lib/pages/offre_emploi_details_page.dart
@@ -4,9 +4,11 @@ import 'package:flutter_svg/flutter_svg.dart';
 import 'package:matomo/matomo.dart';
 import 'package:pass_emploi_app/analytics/analytics_constants.dart';
 import 'package:pass_emploi_app/models/offre_emploi_details.dart';
+import 'package:pass_emploi_app/network/post_tracking_event_request.dart';
 import 'package:pass_emploi_app/presentation/favori_heart_view_model.dart';
 import 'package:pass_emploi_app/presentation/offre_emploi_details_page_view_model.dart';
 import 'package:pass_emploi_app/redux/actions/named_actions.dart';
+import 'package:pass_emploi_app/redux/actions/tracking_event_action.dart';
 import 'package:pass_emploi_app/redux/states/app_state.dart';
 import 'package:pass_emploi_app/ui/app_colors.dart';
 import 'package:pass_emploi_app/ui/drawables.dart';
@@ -400,7 +402,8 @@ class OffreEmploiDetailsPage extends TraceableStatelessWidget {
       padding: const EdgeInsets.all(16),
       child: Row(
         children: [
-          Expanded(child: ActionButton(onPressed: () => launch(url), label: Strings.postulerButtonTitle)),
+          Expanded(
+              child: ActionButton(onPressed: () => _applyToOffer(context, url), label: Strings.postulerButtonTitle)),
           SizedBox(width: 8),
           FavoriHeart(
             offreId: offreId,
@@ -408,7 +411,7 @@ class OffreEmploiDetailsPage extends TraceableStatelessWidget {
             onFavoriRemoved: shouldPopPageWhenFavoriIsRemoved ? () => Navigator.pop(context) : null,
           ),
           SizedBox(width: 8),
-          ShareButton(url, title),
+          ShareButton(url, title, () =>_shareOffer(context)),
         ],
       ),
     );
@@ -442,5 +445,14 @@ class OffreEmploiDetailsPage extends TraceableStatelessWidget {
         }
       },
     );
+  }
+
+  void _applyToOffer(BuildContext context, String url) {
+    launch(url);
+    StoreProvider.of<AppState>(context).dispatch(RequestTrackingEventAction(EventType.OFFRE_POSTULEE));
+  }
+
+  void _shareOffer(BuildContext context) {
+    StoreProvider.of<AppState>(context).dispatch(RequestTrackingEventAction(EventType.OFFRE_PARTAGEE));
   }
 }

--- a/lib/redux/actions/tracking_event_action.dart
+++ b/lib/redux/actions/tracking_event_action.dart
@@ -1,0 +1,13 @@
+import 'package:pass_emploi_app/network/post_tracking_event_request.dart';
+
+abstract class TrackingEventAction {}
+
+class RequestTrackingEventAction extends TrackingEventAction {
+  final EventType event;
+
+  RequestTrackingEventAction(this.event);
+}
+
+class TrackingEventWithSuccessAction extends TrackingEventAction {}
+
+class TrackingEventFailed extends TrackingEventAction {}

--- a/lib/redux/actions/tracking_event_action.dart
+++ b/lib/redux/actions/tracking_event_action.dart
@@ -7,7 +7,3 @@ class RequestTrackingEventAction extends TrackingEventAction {
 
   RequestTrackingEventAction(this.event);
 }
-
-class TrackingEventWithSuccessAction extends TrackingEventAction {}
-
-class TrackingEventFailed extends TrackingEventAction {}

--- a/lib/redux/middlewares/login_middleware.dart
+++ b/lib/redux/middlewares/login_middleware.dart
@@ -53,7 +53,11 @@ class LoginMiddleware extends MiddlewareClass<AppState> {
 
   void _dispatchLoginSuccess(Store<AppState> store) async {
     final AuthIdToken idToken = (await _authenticator.idToken())!;
-    final user = User(id: idToken.userId, firstName: idToken.firstName, lastName: idToken.lastName);
+    final user = User(
+        id: idToken.userId,
+        firstName: idToken.firstName,
+        lastName: idToken.lastName,
+        loginMode: idToken.getLoginMode());
     store.dispatch(LoginAction.success(user));
   }
 

--- a/lib/redux/middlewares/tracking_event_middleware.dart
+++ b/lib/redux/middlewares/tracking_event_middleware.dart
@@ -9,19 +9,15 @@ class TrackingEventMiddleware extends MiddlewareClass<AppState> {
   TrackingEventMiddleware(this._repository);
 
   @override
-  call(Store<AppState> store, action, NextDispatcher next) async {
+  call(Store<AppState> store, action, NextDispatcher next) {
     next(action);
     if (action is RequestTrackingEventAction) {
-        final loginState = store.state.loginState;
-        if (loginState.isSuccess()) {
-          final userId = loginState.getResultOrThrow().id;
-          final loginMode = loginState.getResultOrThrow().loginMode;
-          final result = await _repository.sendEvent(userId: userId, event: action.event, structure: loginMode);
-          if (result)
-            store.dispatch(TrackingEventWithSuccessAction());
-          else
-            store.dispatch(TrackingEventFailed());
-        }
+      final loginState = store.state.loginState;
+      if (loginState.isSuccess()) {
+        final userId = loginState.getResultOrThrow().id;
+        final loginMode = loginState.getResultOrThrow().loginMode;
+        _repository.sendEvent(userId: userId, event: action.event, loginMode: loginMode);
+      }
     }
   }
 }

--- a/lib/redux/middlewares/tracking_event_middleware.dart
+++ b/lib/redux/middlewares/tracking_event_middleware.dart
@@ -1,0 +1,27 @@
+import 'package:pass_emploi_app/redux/actions/tracking_event_action.dart';
+import 'package:pass_emploi_app/redux/states/app_state.dart';
+import 'package:pass_emploi_app/repositories/tracking_analytics/tracking_event_repository.dart';
+import 'package:redux/redux.dart';
+
+class TrackingEventMiddleware extends MiddlewareClass<AppState> {
+  final TrackingEventRepository _repository;
+
+  TrackingEventMiddleware(this._repository);
+
+  @override
+  call(Store<AppState> store, action, NextDispatcher next) async {
+    next(action);
+    if (action is RequestTrackingEventAction) {
+        final loginState = store.state.loginState;
+        if (loginState.isSuccess()) {
+          final userId = loginState.getResultOrThrow().id;
+          final loginMode = loginState.getResultOrThrow().loginMode;
+          final result = await _repository.sendEvent(userId: userId, event: action.event, structure: loginMode);
+          if (result)
+            store.dispatch(TrackingEventWithSuccessAction());
+          else
+            store.dispatch(TrackingEventFailed());
+        }
+    }
+  }
+}

--- a/lib/redux/store/store_factory.dart
+++ b/lib/redux/store/store_factory.dart
@@ -21,6 +21,7 @@ import 'package:pass_emploi_app/redux/requests/immersion_request.dart';
 import 'package:pass_emploi_app/redux/states/app_state.dart';
 import 'package:pass_emploi_app/repositories/chat_repository.dart';
 import 'package:pass_emploi_app/repositories/crypto/chat_crypto.dart';
+import 'package:pass_emploi_app/repositories/event_tracker_repository.dart';
 import 'package:pass_emploi_app/repositories/firebase_auth_repository.dart';
 import 'package:pass_emploi_app/repositories/immersion_details_repository.dart';
 import 'package:pass_emploi_app/repositories/immersion_repository.dart';
@@ -49,6 +50,7 @@ class StoreFactory {
   final FirebaseAuthRepository firebaseAuthRepository;
   final FirebaseAuthWrapper firebaseAuthWrapper;
   final ChatCrypto chatCrypto;
+  final EventTrackerRepository eventTrackerRepository;
 
   StoreFactory(
     this.authenticator,
@@ -66,6 +68,7 @@ class StoreFactory {
     this.firebaseAuthRepository,
     this.firebaseAuthWrapper,
     this.chatCrypto,
+    this.eventTrackerRepository,
   );
 
   redux.Store<AppState> initializeReduxStore({required AppState initialState}) {

--- a/lib/redux/store/store_factory.dart
+++ b/lib/redux/store/store_factory.dart
@@ -15,13 +15,14 @@ import 'package:pass_emploi_app/redux/middlewares/offre_emploi_favoris_middlewar
 import 'package:pass_emploi_app/redux/middlewares/offre_emploi_middleware.dart';
 import 'package:pass_emploi_app/redux/middlewares/register_push_notification_token_middleware.dart';
 import 'package:pass_emploi_app/redux/middlewares/search_location_middleware.dart';
+import 'package:pass_emploi_app/redux/middlewares/tracking_event_middleware.dart';
 import 'package:pass_emploi_app/redux/middlewares/user_action_middleware.dart';
 import 'package:pass_emploi_app/redux/reducers/app_reducer.dart';
 import 'package:pass_emploi_app/redux/requests/immersion_request.dart';
 import 'package:pass_emploi_app/redux/states/app_state.dart';
 import 'package:pass_emploi_app/repositories/chat_repository.dart';
 import 'package:pass_emploi_app/repositories/crypto/chat_crypto.dart';
-import 'package:pass_emploi_app/repositories/event_tracker_repository.dart';
+import 'package:pass_emploi_app/repositories/tracking_analytics/tracking_event_repository.dart';
 import 'package:pass_emploi_app/repositories/firebase_auth_repository.dart';
 import 'package:pass_emploi_app/repositories/immersion_details_repository.dart';
 import 'package:pass_emploi_app/repositories/immersion_repository.dart';
@@ -50,7 +51,7 @@ class StoreFactory {
   final FirebaseAuthRepository firebaseAuthRepository;
   final FirebaseAuthWrapper firebaseAuthWrapper;
   final ChatCrypto chatCrypto;
-  final EventTrackerRepository eventTrackerRepository;
+  final TrackingEventRepository trackingEventRepository;
 
   StoreFactory(
     this.authenticator,
@@ -68,7 +69,7 @@ class StoreFactory {
     this.firebaseAuthRepository,
     this.firebaseAuthWrapper,
     this.chatCrypto,
-    this.eventTrackerRepository,
+    this.trackingEventRepository,
   );
 
   redux.Store<AppState> initializeReduxStore({required AppState initialState}) {
@@ -86,6 +87,7 @@ class StoreFactory {
         RegisterPushNotificationTokenMiddleware(registerTokenRepository),
         CrashlyticsMiddleware(crashlytics),
         SearchLocationMiddleware(searchLocationRepository),
+        TrackingEventMiddleware(trackingEventRepository),
         Middleware<void, List<Rendezvous>>(rendezvousRepository),
         Middleware<ImmersionRequest, List<Immersion>>(immersionRepository),
         Middleware<String, ImmersionDetails>(immersionDetailsRepository),

--- a/lib/repositories/event_tracker_repository.dart
+++ b/lib/repositories/event_tracker_repository.dart
@@ -1,0 +1,30 @@
+import 'package:http/http.dart';
+import 'package:pass_emploi_app/crashlytics/crashlytics.dart';
+import 'package:pass_emploi_app/network/headers.dart';
+import 'package:pass_emploi_app/network/json_encoder.dart';
+import 'package:pass_emploi_app/network/post_tracking_event_request.dart';
+import 'package:pass_emploi_app/network/status_code.dart';
+
+class EventTrackerRepository {
+  final String _baseUrl;
+  final Client _httpClient;
+  final HeadersBuilder _headersBuilder;
+  final Crashlytics? _crashlytics;
+
+  EventTrackerRepository(this._baseUrl, this._httpClient, this._headersBuilder, [this._crashlytics]);
+
+  Future<bool> sendEvent(String userId, EventType event, StructureType structure) async {
+    final url = Uri.parse(_baseUrl + "/evenements");
+    try {
+      final response = await _httpClient.post(
+        url,
+        headers: await _headersBuilder.headers(userId: userId, contentType: 'application/json'),
+        body: customJsonEncode(PostTrackingEvent(event: event, structure: structure, id: userId)),
+      );
+      if (response.statusCode.isValid()) return true;
+    } catch (e, stack) {
+      _crashlytics?.recordNonNetworkException(e, stack, url);
+    }
+    return false;
+  }
+}

--- a/lib/repositories/tracking_analytics/tracking_event_repository.dart
+++ b/lib/repositories/tracking_analytics/tracking_event_repository.dart
@@ -1,19 +1,20 @@
 import 'package:http/http.dart';
+import 'package:pass_emploi_app/auth/auth_id_token.dart';
 import 'package:pass_emploi_app/crashlytics/crashlytics.dart';
 import 'package:pass_emploi_app/network/headers.dart';
 import 'package:pass_emploi_app/network/json_encoder.dart';
 import 'package:pass_emploi_app/network/post_tracking_event_request.dart';
 import 'package:pass_emploi_app/network/status_code.dart';
 
-class EventTrackerRepository {
+class TrackingEventRepository {
   final String _baseUrl;
   final Client _httpClient;
   final HeadersBuilder _headersBuilder;
   final Crashlytics? _crashlytics;
 
-  EventTrackerRepository(this._baseUrl, this._httpClient, this._headersBuilder, [this._crashlytics]);
+  TrackingEventRepository(this._baseUrl, this._httpClient, this._headersBuilder, [this._crashlytics]);
 
-  Future<bool> sendEvent(String userId, EventType event, StructureType structure) async {
+  Future<bool> sendEvent({required String userId, required EventType event, required LoginStructure structure}) async {
     final url = Uri.parse(_baseUrl + "/evenements");
     try {
       final response = await _httpClient.post(

--- a/lib/repositories/tracking_analytics/tracking_event_repository.dart
+++ b/lib/repositories/tracking_analytics/tracking_event_repository.dart
@@ -14,13 +14,13 @@ class TrackingEventRepository {
 
   TrackingEventRepository(this._baseUrl, this._httpClient, this._headersBuilder, [this._crashlytics]);
 
-  Future<bool> sendEvent({required String userId, required EventType event, required LoginStructure structure}) async {
+  Future<bool> sendEvent({required String userId, required EventType event, required LoginMode loginMode}) async {
     final url = Uri.parse(_baseUrl + "/evenements");
     try {
       final response = await _httpClient.post(
         url,
         headers: await _headersBuilder.headers(userId: userId, contentType: 'application/json'),
-        body: customJsonEncode(PostTrackingEvent(event: event, structure: structure, id: userId)),
+        body: customJsonEncode(PostTrackingEvent(event: event, loginMode: loginMode, id: userId)),
       );
       if (response.statusCode.isValid()) return true;
     } catch (e, stack) {

--- a/lib/widgets/share_button.dart
+++ b/lib/widgets/share_button.dart
@@ -7,8 +7,9 @@ import 'package:share_plus/share_plus.dart';
 class ShareButton extends StatelessWidget {
   final String textToShare;
   final String? subjectForEmail;
+  final VoidCallback? onPressed;
 
-  const ShareButton(this.textToShare, this.subjectForEmail) : super();
+  const ShareButton(this.textToShare, this.subjectForEmail, this.onPressed) : super();
 
   @override
   Widget build(BuildContext context) {
@@ -17,7 +18,10 @@ class ShareButton extends StatelessWidget {
         color: Colors.transparent,
         shape: CircleBorder(side: BorderSide(color: AppColors.nightBlue)),
         child: InkWell(
-          onTap: () => Share.share(textToShare, subject: subjectForEmail),
+          onTap: () {
+            if (onPressed != null) onPressed!();
+            Share.share(textToShare, subject: subjectForEmail);
+          },
           child: Container(
             width: 48,
             height: 48,

--- a/lib/widgets/user_action_details_bottom_sheet.dart
+++ b/lib/widgets/user_action_details_bottom_sheet.dart
@@ -223,9 +223,7 @@ class _UserActionDetailsBottomSheetState extends State<UserActionDetailsBottomSh
         crossAxisAlignment: CrossAxisAlignment.stretch,
         children: [
           PrimaryActionButton.simple(
-            onPressed: detailsViewModel.displayState == UserActionDetailsDisplayState.SHOW_LOADING
-                ? null
-                : () => detailsViewModel.onDelete(widget.actionViewModel.id),
+            onPressed: () => _onDeleteAction(detailsViewModel),
             label: Strings.deleteAction,
             textColor: AppColors.franceRed,
             backgroundColor: AppColors.franceRedAlpha05,
@@ -246,7 +244,14 @@ class _UserActionDetailsBottomSheetState extends State<UserActionDetailsBottomSh
     );
   }
 
-  _dismissBottomSheetIfNeeded(BuildContext context, UserActionDetailsViewModel viewModel) {
+  void _onDeleteAction(UserActionDetailsViewModel detailsViewModel) {
+    if (detailsViewModel.displayState != UserActionDetailsDisplayState.SHOW_LOADING) {
+      detailsViewModel.onDelete(widget.actionViewModel.id);
+      MatomoTracker.trackScreenWithName(AnalyticsActionNames.deleteUserAction, AnalyticsScreenNames.userActionDetails);
+    }
+  }
+
+  void _dismissBottomSheetIfNeeded(BuildContext context, UserActionDetailsViewModel viewModel) {
     if (viewModel.displayState == UserActionDetailsDisplayState.TO_DISMISS)
       Navigator.pop(context);
     else if (viewModel.displayState == UserActionDetailsDisplayState.TO_DISMISS_AFTER_DELETION)

--- a/test/auth/auth_access_token_retriever_test.dart
+++ b/test/auth/auth_access_token_retriever_test.dart
@@ -98,6 +98,7 @@ class AuthenticatorLoggedInAndValidIdTokenStub extends Authenticator {
         firstName: "F",
         lastName: "L",
         expiresAt: (DateTime.now().millisecondsSinceEpoch ~/ 1000) + 1000,
+        loginStructure: 'MILO',
       );
 
   @override
@@ -111,7 +112,13 @@ class AuthenticatorLoggedInAndInvalidIdTokenStub extends Authenticator {
       : super(DummyAuthWrapper(), configuration(), SharedPreferencesSpy());
 
   @override
-  Future<AuthIdToken?> idToken() async => AuthIdToken(userId: "id", firstName: "F", lastName: "L", expiresAt: 0);
+  Future<AuthIdToken?> idToken() async => AuthIdToken(
+        userId: "id",
+        firstName: "F",
+        lastName: "L",
+        expiresAt: 0,
+        loginStructure: 'MILO',
+      );
 
   @override
   Future<String?> accessToken() async => "Access token";

--- a/test/auth/auth_access_token_retriever_test.dart
+++ b/test/auth/auth_access_token_retriever_test.dart
@@ -98,7 +98,7 @@ class AuthenticatorLoggedInAndValidIdTokenStub extends Authenticator {
         firstName: "F",
         lastName: "L",
         expiresAt: (DateTime.now().millisecondsSinceEpoch ~/ 1000) + 1000,
-        loginStructure: 'MILO',
+        loginMode: 'MILO',
       );
 
   @override
@@ -117,7 +117,7 @@ class AuthenticatorLoggedInAndInvalidIdTokenStub extends Authenticator {
         firstName: "F",
         lastName: "L",
         expiresAt: 0,
-        loginStructure: 'MILO',
+        loginMode: 'MILO',
       );
 
   @override

--- a/test/auth/auth_id_token_test.dart
+++ b/test/auth/auth_id_token_test.dart
@@ -16,5 +16,13 @@ void main() {
 }
 
 void _assertIsValid(int expiresAt, bool expected) {
-  expect(AuthIdToken(userId: "", lastName: "", firstName: "", expiresAt: expiresAt).isValid(), expected);
+  expect(
+      AuthIdToken(
+        userId: "",
+        lastName: "",
+        firstName: "",
+        expiresAt: expiresAt,
+        loginStructure: 'MILO',
+      ).isValid(),
+      expected);
 }

--- a/test/auth/auth_id_token_test.dart
+++ b/test/auth/auth_id_token_test.dart
@@ -17,12 +17,13 @@ void main() {
 
 void _assertIsValid(int expiresAt, bool expected) {
   expect(
-      AuthIdToken(
-        userId: "",
-        lastName: "",
-        firstName: "",
-        expiresAt: expiresAt,
-        loginStructure: 'MILO',
-      ).isValid(),
-      expected);
+    AuthIdToken(
+      userId: "",
+      lastName: "",
+      firstName: "",
+      expiresAt: expiresAt,
+      loginMode: 'MILO',
+    ).isValid(),
+    expected,
+  );
 }

--- a/test/auth/authenticator_test.dart
+++ b/test/auth/authenticator_test.dart
@@ -229,6 +229,7 @@ void main() {
           firstName: "Gabriel",
           lastName: "Android",
           expiresAt: 1638874410,
+          loginStructure: 'PASS_EMPLOI',
         ));
   });
 

--- a/test/auth/authenticator_test.dart
+++ b/test/auth/authenticator_test.dart
@@ -229,7 +229,7 @@ void main() {
           firstName: "Gabriel",
           lastName: "Android",
           expiresAt: 1638874410,
-          loginStructure: 'PASS_EMPLOI',
+          loginMode: 'PASS_EMPLOI',
         ));
   });
 

--- a/test/doubles/dummies.dart
+++ b/test/doubles/dummies.dart
@@ -10,6 +10,7 @@ import 'package:pass_emploi_app/push/push_notification_manager.dart';
 import 'package:pass_emploi_app/redux/states/app_state.dart';
 import 'package:pass_emploi_app/repositories/chat_repository.dart';
 import 'package:pass_emploi_app/repositories/crypto/chat_crypto.dart';
+import 'package:pass_emploi_app/repositories/event_tracker_repository.dart';
 import 'package:pass_emploi_app/repositories/firebase_auth_repository.dart';
 import 'package:pass_emploi_app/repositories/immersion_details_repository.dart';
 import 'package:pass_emploi_app/repositories/immersion_repository.dart';
@@ -117,4 +118,7 @@ class DummyImmersionDetailsRepository extends ImmersionDetailsRepository {
 
 class DummyChatCrypto extends ChatCrypto {
   DummyChatCrypto() : super();
+}
+class DummyEventTrackerRepositoryextends extends EventTrackerRepository {
+  DummyEventTrackerRepositoryextends() : super("", DummyHttpClient(), DummyHeadersBuilder());
 }

--- a/test/doubles/dummies.dart
+++ b/test/doubles/dummies.dart
@@ -10,7 +10,7 @@ import 'package:pass_emploi_app/push/push_notification_manager.dart';
 import 'package:pass_emploi_app/redux/states/app_state.dart';
 import 'package:pass_emploi_app/repositories/chat_repository.dart';
 import 'package:pass_emploi_app/repositories/crypto/chat_crypto.dart';
-import 'package:pass_emploi_app/repositories/event_tracker_repository.dart';
+import 'package:pass_emploi_app/repositories/tracking_analytics/tracking_event_repository.dart';
 import 'package:pass_emploi_app/repositories/firebase_auth_repository.dart';
 import 'package:pass_emploi_app/repositories/immersion_details_repository.dart';
 import 'package:pass_emploi_app/repositories/immersion_repository.dart';
@@ -119,6 +119,6 @@ class DummyImmersionDetailsRepository extends ImmersionDetailsRepository {
 class DummyChatCrypto extends ChatCrypto {
   DummyChatCrypto() : super();
 }
-class DummyEventTrackerRepositoryextends extends EventTrackerRepository {
-  DummyEventTrackerRepositoryextends() : super("", DummyHttpClient(), DummyHeadersBuilder());
+class DummyTrackingEventRepository extends TrackingEventRepository {
+  DummyTrackingEventRepository() : super("", DummyHttpClient(), DummyHeadersBuilder());
 }

--- a/test/doubles/dummies.dart
+++ b/test/doubles/dummies.dart
@@ -119,6 +119,7 @@ class DummyImmersionDetailsRepository extends ImmersionDetailsRepository {
 class DummyChatCrypto extends ChatCrypto {
   DummyChatCrypto() : super();
 }
+
 class DummyTrackingEventRepository extends TrackingEventRepository {
   DummyTrackingEventRepository() : super("", DummyHttpClient(), DummyHeadersBuilder());
 }

--- a/test/doubles/fixtures.dart
+++ b/test/doubles/fixtures.dart
@@ -14,14 +14,14 @@ User mockUser({id: ""}) => User(
       id: id,
       firstName: "",
       lastName: "",
-      loginMode: LoginStructure.MILO,
+      loginMode: LoginMode.MILO,
     );
 
 State<User> successUserState() => State<User>.success(User(
       id: "id",
       firstName: "F",
       lastName: "L",
-      loginMode: LoginStructure.MILO,
+      loginMode: LoginMode.MILO,
     ));
 
 AppState loggedInState() => AppState.initialState().copyWith(loginState: successUserState());

--- a/test/doubles/fixtures.dart
+++ b/test/doubles/fixtures.dart
@@ -1,4 +1,5 @@
 import 'package:http/http.dart';
+import 'package:pass_emploi_app/auth/auth_id_token.dart';
 import 'package:pass_emploi_app/auth/auth_token_response.dart';
 import 'package:pass_emploi_app/configuration/configuration.dart';
 import 'package:pass_emploi_app/models/immersion.dart';
@@ -9,9 +10,19 @@ import 'package:pass_emploi_app/models/user.dart';
 import 'package:pass_emploi_app/redux/states/app_state.dart';
 import 'package:pass_emploi_app/redux/states/state.dart';
 
-User mockUser({id: ""}) => User(id: id, firstName: "", lastName: "");
+User mockUser({id: ""}) => User(
+      id: id,
+      firstName: "",
+      lastName: "",
+      loginMode: LoginStructure.MILO,
+    );
 
-State<User> successUserState() => State<User>.success(User(id: "id", firstName: "F", lastName: "L"));
+State<User> successUserState() => State<User>.success(User(
+      id: "id",
+      firstName: "F",
+      lastName: "L",
+      loginMode: LoginStructure.MILO,
+    ));
 
 AppState loggedInState() => AppState.initialState().copyWith(loginState: successUserState());
 

--- a/test/doubles/stubs.dart
+++ b/test/doubles/stubs.dart
@@ -119,7 +119,13 @@ class AuthenticatorLoggedInStub extends Authenticator {
   Future<bool> isLoggedIn() async => true;
 
   @override
-  Future<AuthIdToken?> idToken() async=> AuthIdToken(userId: "id", firstName: "F", lastName: "L", expiresAt: 100000000);
+  Future<AuthIdToken?> idToken() async => AuthIdToken(
+        userId: "id",
+        firstName: "F",
+        lastName: "L",
+        expiresAt: 100000000,
+        loginStructure: "MILO",
+      );
 }
 
 class AuthenticatorNotLoggedInStub extends Authenticator {

--- a/test/doubles/stubs.dart
+++ b/test/doubles/stubs.dart
@@ -124,7 +124,7 @@ class AuthenticatorLoggedInStub extends Authenticator {
         firstName: "F",
         lastName: "L",
         expiresAt: 100000000,
-        loginStructure: "MILO",
+        loginMode: "MILO",
       );
 }
 

--- a/test/feature/login_test.dart
+++ b/test/feature/login_test.dart
@@ -44,7 +44,7 @@ void main() {
             id: "id",
             firstName: "F",
             lastName: "L",
-            loginMode: LoginStructure.MILO,
+            loginMode: LoginMode.MILO,
           ));
     });
 
@@ -84,7 +84,7 @@ void main() {
             id: "id",
             firstName: "F",
             lastName: "L",
-            loginMode: LoginStructure.MILO,
+            loginMode: LoginMode.MILO,
           ));
     });
 
@@ -108,7 +108,7 @@ void main() {
             id: "id",
             firstName: "F",
             lastName: "L",
-            loginMode: LoginStructure.MILO,
+            loginMode: LoginMode.MILO,
           ));
     });
 

--- a/test/feature/login_test.dart
+++ b/test/feature/login_test.dart
@@ -1,4 +1,5 @@
 import 'package:flutter_test/flutter_test.dart';
+import 'package:pass_emploi_app/auth/auth_id_token.dart';
 import 'package:pass_emploi_app/auth/authenticator.dart';
 import 'package:pass_emploi_app/models/rendezvous.dart';
 import 'package:pass_emploi_app/models/user.dart';
@@ -37,7 +38,14 @@ void main() {
       // Then
       final loginState = resultState.loginState;
       expect(loginState.isSuccess(), isTrue);
-      expect(loginState.getResultOrThrow(), User(id: "id", firstName: "F", lastName: "L"));
+      expect(
+          loginState.getResultOrThrow(),
+          User(
+            id: "id",
+            firstName: "F",
+            lastName: "L",
+            loginMode: LoginStructure.MILO,
+          ));
     });
 
     test('user is not logged in if she was not previously logged in', () async {
@@ -70,7 +78,14 @@ void main() {
       // Then
       expect(await displayedLoading, true);
       final loginState = resultState.loginState;
-      expect(loginState.getResultOrThrow(), User(id: "id", firstName: "F", lastName: "L"));
+      expect(
+          loginState.getResultOrThrow(),
+          User(
+            id: "id",
+            firstName: "F",
+            lastName: "L",
+            loginMode: LoginStructure.MILO,
+          ));
     });
 
     test('user is properly logged in when login successes in SIMILO authentication mode', () async {
@@ -87,7 +102,14 @@ void main() {
       // Then
       expect(await displayedLoading, true);
       final loginState = resultState.loginState;
-      expect(loginState.getResultOrThrow(), User(id: "id", firstName: "F", lastName: "L"));
+      expect(
+          loginState.getResultOrThrow(),
+          User(
+            id: "id",
+            firstName: "F",
+            lastName: "L",
+            loginMode: LoginStructure.MILO,
+          ));
     });
 
     test('user is not logged in when login fails', () async {

--- a/test/redux/middlewares/create_user_action_middleware_test.dart
+++ b/test/redux/middlewares/create_user_action_middleware_test.dart
@@ -1,4 +1,5 @@
 import 'package:flutter_test/flutter_test.dart';
+import 'package:pass_emploi_app/auth/auth_id_token.dart';
 import 'package:pass_emploi_app/models/user.dart';
 import 'package:pass_emploi_app/models/user_action.dart';
 import 'package:pass_emploi_app/redux/actions/user_action_actions.dart';
@@ -39,8 +40,13 @@ main() {
     final createUserAction = CreateUserAction("content", "comment", UserActionStatus.DONE);
     final store = Store<AppState>(
       storeSpy.reducer,
-      initialState: AppState.initialState()
-          .copyWith(loginState: State<User>.success(User(id: "error", firstName: "F", lastName: "L"))),
+      initialState: AppState.initialState().copyWith(
+          loginState: State<User>.success(User(
+        id: "error",
+        firstName: "F",
+        lastName: "L",
+        loginMode: LoginStructure.MILO,
+      ))),
     );
 
     // When

--- a/test/redux/middlewares/create_user_action_middleware_test.dart
+++ b/test/redux/middlewares/create_user_action_middleware_test.dart
@@ -45,7 +45,7 @@ main() {
         id: "error",
         firstName: "F",
         lastName: "L",
-        loginMode: LoginStructure.MILO,
+        loginMode: LoginMode.MILO,
       ))),
     );
 

--- a/test/redux/middlewares/register_push_notification_token_middleware_test.dart
+++ b/test/redux/middlewares/register_push_notification_token_middleware_test.dart
@@ -38,7 +38,7 @@ void main() {
       id: "1",
       firstName: "first-name",
       lastName: "last-name",
-      loginMode: LoginStructure.MILO,
+      loginMode: LoginMode.MILO,
     );
     final action = LoginAction.success(user);
 

--- a/test/redux/middlewares/register_push_notification_token_middleware_test.dart
+++ b/test/redux/middlewares/register_push_notification_token_middleware_test.dart
@@ -1,4 +1,5 @@
 import 'package:flutter_test/flutter_test.dart';
+import 'package:pass_emploi_app/auth/auth_id_token.dart';
 import 'package:pass_emploi_app/models/user.dart';
 import 'package:pass_emploi_app/redux/actions/login_actions.dart';
 import 'package:pass_emploi_app/redux/actions/named_actions.dart';
@@ -33,7 +34,12 @@ void main() {
   });
 
   test('call when action is LoginAction.success should call repository to register token', () {
-    final user = User(id: "1", firstName: "first-name", lastName: "last-name");
+    final user = User(
+      id: "1",
+      firstName: "first-name",
+      lastName: "last-name",
+      loginMode: LoginStructure.MILO,
+    );
     final action = LoginAction.success(user);
 
     final middleware = RegisterPushNotificationTokenMiddleware(_repositorySpy);

--- a/test/redux/middlewares/tracking_event_middleware_test.dart
+++ b/test/redux/middlewares/tracking_event_middleware_test.dart
@@ -1,0 +1,87 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:pass_emploi_app/auth/auth_id_token.dart';
+import 'package:pass_emploi_app/models/user.dart';
+import 'package:pass_emploi_app/network/post_tracking_event_request.dart';
+import 'package:pass_emploi_app/redux/actions/tracking_event_action.dart';
+import 'package:pass_emploi_app/redux/middlewares/tracking_event_middleware.dart';
+import 'package:pass_emploi_app/redux/states/app_state.dart';
+import 'package:pass_emploi_app/redux/states/state.dart';
+import 'package:pass_emploi_app/repositories/tracking_analytics/tracking_event_repository.dart';
+import 'package:redux/redux.dart';
+
+import '../../doubles/dummies.dart';
+import '../../doubles/fixtures.dart';
+
+main() {
+  final repository = TrackingEventRepositoryMock();
+  final middleware = TrackingEventMiddleware(repository);
+
+  test('call should call tracking event repository with success dispatch', () async {
+    // Given
+    final storeSpy = StoreSpy();
+    final trackingEventAction = RequestTrackingEventAction(EventType.MESSAGE_ENVOYE);
+    final store = Store<AppState>(
+      storeSpy.reducer,
+      initialState: AppState.initialState().copyWith(loginState: successUserState()),
+    );
+
+    // When
+    await middleware.call(store, trackingEventAction, (action) => {});
+
+    // Then
+    expect(repository.wasCalled, true);
+    expect(storeSpy.calledWithSuccess, true);
+  });
+
+  test('call should dispatch un error action', () async {
+    // Given
+    final storeSpy = StoreSpy();
+    final trackingEventAction = RequestTrackingEventAction(EventType.OFFRE_PARTAGEE);
+    final store = Store<AppState>(
+      storeSpy.reducer,
+      initialState: AppState.initialState().copyWith(
+          loginState: State<User>.success(
+        User(
+          id: "error",
+          firstName: "F",
+          lastName: "L",
+          loginMode: LoginStructure.MILO,
+        ),
+      )),
+    );
+
+    // When
+    await middleware.call(store, trackingEventAction, (action) => {});
+
+    // Then
+    expect(repository.wasCalled, true);
+    expect(storeSpy.calledWithFailure, true);
+  });
+}
+
+class StoreSpy {
+  var calledWithSuccess = false;
+  var calledWithFailure = false;
+
+  AppState reducer(AppState currentState, dynamic action) {
+    if (action is TrackingEventWithSuccessAction) {
+      calledWithSuccess = true;
+    }
+    if (action is TrackingEventFailed) {
+      calledWithFailure = true;
+    }
+    return currentState;
+  }
+}
+
+class TrackingEventRepositoryMock extends TrackingEventRepository {
+  bool wasCalled = false;
+
+  TrackingEventRepositoryMock() : super("", DummyHttpClient(), DummyHeadersBuilder());
+
+  @override
+  Future<bool> sendEvent({required String userId, required EventType event, required LoginStructure structure}) async {
+    wasCalled = true;
+    return userId == "error" ? false : true;
+  }
+}

--- a/test/redux/middlewares/tracking_event_middleware_test.dart
+++ b/test/redux/middlewares/tracking_event_middleware_test.dart
@@ -16,7 +16,7 @@ main() {
   final repository = TrackingEventRepositoryMock();
   final middleware = TrackingEventMiddleware(repository);
 
-  test('call should call tracking event repository with success dispatch', () async {
+  test('call should call tracking event repository', () async {
     // Given
     final storeSpy = StoreSpy();
     final trackingEventAction = RequestTrackingEventAction(EventType.MESSAGE_ENVOYE);
@@ -30,46 +30,12 @@ main() {
 
     // Then
     expect(repository.wasCalled, true);
-    expect(storeSpy.calledWithSuccess, true);
-  });
-
-  test('call should dispatch un error action', () async {
-    // Given
-    final storeSpy = StoreSpy();
-    final trackingEventAction = RequestTrackingEventAction(EventType.OFFRE_PARTAGEE);
-    final store = Store<AppState>(
-      storeSpy.reducer,
-      initialState: AppState.initialState().copyWith(
-          loginState: State<User>.success(
-        User(
-          id: "error",
-          firstName: "F",
-          lastName: "L",
-          loginMode: LoginStructure.MILO,
-        ),
-      )),
-    );
-
-    // When
-    await middleware.call(store, trackingEventAction, (action) => {});
-
-    // Then
-    expect(repository.wasCalled, true);
-    expect(storeSpy.calledWithFailure, true);
   });
 }
 
 class StoreSpy {
-  var calledWithSuccess = false;
-  var calledWithFailure = false;
 
   AppState reducer(AppState currentState, dynamic action) {
-    if (action is TrackingEventWithSuccessAction) {
-      calledWithSuccess = true;
-    }
-    if (action is TrackingEventFailed) {
-      calledWithFailure = true;
-    }
     return currentState;
   }
 }
@@ -80,7 +46,7 @@ class TrackingEventRepositoryMock extends TrackingEventRepository {
   TrackingEventRepositoryMock() : super("", DummyHttpClient(), DummyHeadersBuilder());
 
   @override
-  Future<bool> sendEvent({required String userId, required EventType event, required LoginStructure structure}) async {
+  Future<bool> sendEvent({required String userId, required EventType event, required LoginMode loginMode}) async {
     wasCalled = true;
     return userId == "error" ? false : true;
   }

--- a/test/repositories/event_tracking_repository_test.dart
+++ b/test/repositories/event_tracking_repository_test.dart
@@ -1,0 +1,50 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:http/http.dart';
+import 'package:http/testing.dart';
+import 'package:pass_emploi_app/network/post_tracking_event_request.dart';
+import 'package:pass_emploi_app/repositories/event_tracker_repository.dart';
+
+import '../doubles/fixtures.dart';
+import '../doubles/stubs.dart';
+
+void main() {
+  test('sendEvent should successfully send event when response is valid', () async {
+    // Given
+    final httpClient = MockClient((request) async {
+      if (request.method != "POST") return invalidHttpResponse();
+      if (!request.url.toString().startsWith("BASE_URL/evenements")) return invalidHttpResponse();
+      return Response("", 201);
+    });
+    final repository = EventTrackerRepository("BASE_URL", httpClient, HeadersBuilderStub());
+
+    // When
+    final isEventSentWithSuccess = await repository.sendEvent("userId", EventType.MESSAGE_ENVOYE, StructureType.MILO);
+
+    // Then
+    expect(isEventSentWithSuccess, true);
+  });
+
+  test('sendEvent should return false when response in invalid', () async {
+    // Given
+    final httpClient = MockClient((request) async => invalidHttpResponse());
+    final repository = EventTrackerRepository("BASE_URL", httpClient, HeadersBuilderStub());
+
+    // When
+    final isEventSentWithSuccess = await repository.sendEvent("userId", EventType.MESSAGE_ENVOYE, StructureType.MILO);
+
+    // Then
+    expect(isEventSentWithSuccess, false);
+  });
+
+  test('sendEvent should return false when response throws exception', () async {
+    // Given
+    final httpClient = MockClient((request) async => throw Exception());
+    final repository = EventTrackerRepository("BASE_URL", httpClient, HeadersBuilderStub());
+
+    // When
+    final isEventSentWithSuccess = await repository.sendEvent("userId", EventType.MESSAGE_ENVOYE, StructureType.MILO);
+
+    // Then
+    expect(isEventSentWithSuccess, false);
+  });
+}

--- a/test/repositories/tracking_event_repository_test.dart
+++ b/test/repositories/tracking_event_repository_test.dart
@@ -1,8 +1,9 @@
 import 'package:flutter_test/flutter_test.dart';
 import 'package:http/http.dart';
 import 'package:http/testing.dart';
+import 'package:pass_emploi_app/auth/auth_id_token.dart';
 import 'package:pass_emploi_app/network/post_tracking_event_request.dart';
-import 'package:pass_emploi_app/repositories/event_tracker_repository.dart';
+import 'package:pass_emploi_app/repositories/tracking_analytics/tracking_event_repository.dart';
 
 import '../doubles/fixtures.dart';
 import '../doubles/stubs.dart';
@@ -15,10 +16,14 @@ void main() {
       if (!request.url.toString().startsWith("BASE_URL/evenements")) return invalidHttpResponse();
       return Response("", 201);
     });
-    final repository = EventTrackerRepository("BASE_URL", httpClient, HeadersBuilderStub());
+    final repository = TrackingEventRepository("BASE_URL", httpClient, HeadersBuilderStub());
 
     // When
-    final isEventSentWithSuccess = await repository.sendEvent("userId", EventType.MESSAGE_ENVOYE, StructureType.MILO);
+    final isEventSentWithSuccess = await repository.sendEvent(
+      userId: "userId",
+      event: EventType.MESSAGE_ENVOYE,
+      structure: LoginStructure.MILO,
+    );
 
     // Then
     expect(isEventSentWithSuccess, true);
@@ -27,10 +32,14 @@ void main() {
   test('sendEvent should return false when response in invalid', () async {
     // Given
     final httpClient = MockClient((request) async => invalidHttpResponse());
-    final repository = EventTrackerRepository("BASE_URL", httpClient, HeadersBuilderStub());
+    final repository = TrackingEventRepository("BASE_URL", httpClient, HeadersBuilderStub());
 
     // When
-    final isEventSentWithSuccess = await repository.sendEvent("userId", EventType.MESSAGE_ENVOYE, StructureType.MILO);
+    final isEventSentWithSuccess = await repository.sendEvent(
+      userId: "userId",
+      event: EventType.MESSAGE_ENVOYE,
+      structure: LoginStructure.MILO,
+    );
 
     // Then
     expect(isEventSentWithSuccess, false);
@@ -39,10 +48,14 @@ void main() {
   test('sendEvent should return false when response throws exception', () async {
     // Given
     final httpClient = MockClient((request) async => throw Exception());
-    final repository = EventTrackerRepository("BASE_URL", httpClient, HeadersBuilderStub());
+    final repository = TrackingEventRepository("BASE_URL", httpClient, HeadersBuilderStub());
 
     // When
-    final isEventSentWithSuccess = await repository.sendEvent("userId", EventType.MESSAGE_ENVOYE, StructureType.MILO);
+    final isEventSentWithSuccess = await repository.sendEvent(
+      userId: "userId",
+      event: EventType.MESSAGE_ENVOYE,
+      structure: LoginStructure.MILO,
+    );
 
     // Then
     expect(isEventSentWithSuccess, false);

--- a/test/repositories/tracking_event_repository_test.dart
+++ b/test/repositories/tracking_event_repository_test.dart
@@ -22,7 +22,7 @@ void main() {
     final isEventSentWithSuccess = await repository.sendEvent(
       userId: "userId",
       event: EventType.MESSAGE_ENVOYE,
-      structure: LoginStructure.MILO,
+      loginMode: LoginMode.MILO,
     );
 
     // Then
@@ -38,7 +38,7 @@ void main() {
     final isEventSentWithSuccess = await repository.sendEvent(
       userId: "userId",
       event: EventType.MESSAGE_ENVOYE,
-      structure: LoginStructure.MILO,
+      loginMode: LoginMode.MILO,
     );
 
     // Then
@@ -54,7 +54,7 @@ void main() {
     final isEventSentWithSuccess = await repository.sendEvent(
       userId: "userId",
       event: EventType.MESSAGE_ENVOYE,
-      structure: LoginStructure.MILO,
+      loginMode: LoginMode.MILO,
     );
 
     // Then

--- a/test/utils/test_setup.dart
+++ b/test/utils/test_setup.dart
@@ -5,6 +5,7 @@ import 'package:pass_emploi_app/redux/states/app_state.dart';
 import 'package:pass_emploi_app/redux/store/store_factory.dart';
 import 'package:pass_emploi_app/repositories/chat_repository.dart';
 import 'package:pass_emploi_app/repositories/crypto/chat_crypto.dart';
+import 'package:pass_emploi_app/repositories/event_tracker_repository.dart';
 import 'package:pass_emploi_app/repositories/firebase_auth_repository.dart';
 import 'package:pass_emploi_app/repositories/immersion_details_repository.dart';
 import 'package:pass_emploi_app/repositories/immersion_repository.dart';
@@ -35,6 +36,7 @@ class TestStoreFactory {
   FirebaseAuthRepository firebaseAuthRepository = DummyFirebaseAuthRepository();
   FirebaseAuthWrapper firebaseAuthWrapper = DummyFirebaseAuthWrapper();
   ChatCrypto chatCrypto = DummyChatCrypto();
+  EventTrackerRepository eventTrackerRepository = DummyEventTrackerRepositoryextends();
 
   Store<AppState> initializeReduxStore({required AppState initialState}) {
     return StoreFactory(
@@ -53,6 +55,7 @@ class TestStoreFactory {
       firebaseAuthRepository,
       firebaseAuthWrapper,
       chatCrypto,
+      eventTrackerRepository,
     ).initializeReduxStore(initialState: initialState);
   }
 }

--- a/test/utils/test_setup.dart
+++ b/test/utils/test_setup.dart
@@ -5,7 +5,7 @@ import 'package:pass_emploi_app/redux/states/app_state.dart';
 import 'package:pass_emploi_app/redux/store/store_factory.dart';
 import 'package:pass_emploi_app/repositories/chat_repository.dart';
 import 'package:pass_emploi_app/repositories/crypto/chat_crypto.dart';
-import 'package:pass_emploi_app/repositories/event_tracker_repository.dart';
+import 'package:pass_emploi_app/repositories/tracking_analytics/tracking_event_repository.dart';
 import 'package:pass_emploi_app/repositories/firebase_auth_repository.dart';
 import 'package:pass_emploi_app/repositories/immersion_details_repository.dart';
 import 'package:pass_emploi_app/repositories/immersion_repository.dart';
@@ -36,7 +36,7 @@ class TestStoreFactory {
   FirebaseAuthRepository firebaseAuthRepository = DummyFirebaseAuthRepository();
   FirebaseAuthWrapper firebaseAuthWrapper = DummyFirebaseAuthWrapper();
   ChatCrypto chatCrypto = DummyChatCrypto();
-  EventTrackerRepository eventTrackerRepository = DummyEventTrackerRepositoryextends();
+  TrackingEventRepository trackingEventRepository = DummyTrackingEventRepository();
 
   Store<AppState> initializeReduxStore({required AppState initialState}) {
     return StoreFactory(
@@ -55,7 +55,7 @@ class TestStoreFactory {
       firebaseAuthRepository,
       firebaseAuthWrapper,
       chatCrypto,
-      eventTrackerRepository,
+      trackingEventRepository,
     ).initializeReduxStore(initialState: initialState);
   }
 }


### PR DESCRIPTION
Grâce à ce ticket => [TRELLO](https://trello.com/c/m0wfMOrY/191-us-191-api-magique-pour-envoi-message-et-clic-sur-postuler) il est néanmoins possible d'envoyer les actions de tracking à l'api `\evenements`.

J'ai aussi profité de ce PR pour envoyer à matomo l'event lors qu'on delete une action => [TAGGING](https://docs.google.com/spreadsheets/d/1K2vRjfQ79TDvffmKckyW41RpSYeUgW8o6-okYHcl9rI/edit?pli=1#gid=1763545677)