### PR TITLE
[FIX] 303 - Regression UI sur le tri des actions

### DIFF
--- a/lib/pages/user_action_list_page.dart
+++ b/lib/pages/user_action_list_page.dart
@@ -102,7 +102,7 @@ class _UserActionListPageState extends State<UserActionListPage> {
   Widget _listItem(BuildContext context, UserActionListPageItem item, UserActionListPageViewModel viewModel) {
     if (item is UserActionListSubtitle) {
       return Padding(
-        padding: const EdgeInsets.only(top: 16),
+        padding: const EdgeInsets.only(top: Margins.spacing_base),
         child: Text(item.title, style: TextStyles.textMBold),
       );
     } else {

--- a/lib/pages/user_action_list_page.dart
+++ b/lib/pages/user_action_list_page.dart
@@ -13,7 +13,7 @@ import 'package:pass_emploi_app/ui/margins.dart';
 import 'package:pass_emploi_app/ui/strings.dart';
 import 'package:pass_emploi_app/ui/text_styles.dart';
 import 'package:pass_emploi_app/widgets/bottom_sheets.dart';
-import 'package:pass_emploi_app/widgets/cards/event_card.dart';
+import 'package:pass_emploi_app/widgets/cards/user_action_card.dart';
 import 'package:pass_emploi_app/widgets/default_animated_switcher.dart';
 import 'package:pass_emploi_app/widgets/primary_action_button.dart';
 import 'package:pass_emploi_app/widgets/retry.dart';
@@ -100,19 +100,23 @@ class _UserActionListPageState extends State<UserActionListPage> {
   Container _listSeparator() => Container(height: Margins.spacing_base);
 
   Widget _listItem(BuildContext context, UserActionListPageItem item, UserActionListPageViewModel viewModel) {
-    return _tapListener(context, (item as UserActionListItemViewModel).viewModel, viewModel);
+    if (item is UserActionListSubtitle) {
+      return Padding(
+        padding: const EdgeInsets.only(top: 16),
+        child: Text(item.title, style: TextStyles.textMBold),
+      );
+    } else {
+      return _tapListener(context, (item as UserActionListItemViewModel).viewModel, viewModel);
+    }
   }
 
   Widget _tapListener(BuildContext context, UserActionViewModel item, UserActionListPageViewModel viewModel) {
-    return EventCard(
+    return UserActionCard(
       onTap: () => showUserActionBottomSheet(
         context: context,
         builder: (context) => UserActionDetailsBottomSheet(item),
       ).then((value) => _onUserActionDetailsDismissed(context, value, viewModel)),
-      titre: item.content,
-      sousTitre: item.comment,
-      statut: item.status,
-      derniereModification: item.lastUpdate,
+      viewModel: item,
     );
   }
 

--- a/lib/presentation/user_action_list_page_view_model.dart
+++ b/lib/presentation/user_action_list_page_view_model.dart
@@ -4,6 +4,7 @@ import 'package:pass_emploi_app/presentation/user_action_view_model.dart';
 import 'package:pass_emploi_app/redux/actions/user_action_actions.dart';
 import 'package:pass_emploi_app/redux/states/app_state.dart';
 import 'package:pass_emploi_app/redux/states/state.dart';
+import 'package:pass_emploi_app/ui/strings.dart';
 import 'package:redux/redux.dart';
 
 class UserActionListPageViewModel extends Equatable {
@@ -74,12 +75,22 @@ List<UserActionListPageItem> _listItems({
   return [
     ...activeItems.map((e) => UserActionListItemViewModel(e)),
     if (doneItems.isNotEmpty) ...[
+      UserActionListSubtitle(Strings.doneActionsTitle),
       ...doneItems.map((e) => UserActionListItemViewModel(e)),
     ]
   ];
 }
 
 abstract class UserActionListPageItem extends Equatable {}
+
+class UserActionListSubtitle extends UserActionListPageItem {
+  final String title;
+
+  UserActionListSubtitle(this.title);
+
+  @override
+  List<Object?> get props => [title];
+}
 
 class UserActionListItemViewModel extends UserActionListPageItem {
   final UserActionViewModel viewModel;

--- a/lib/presentation/user_action_view_model.dart
+++ b/lib/presentation/user_action_view_model.dart
@@ -10,9 +10,9 @@ import 'package:pass_emploi_app/utils/date_extensions.dart';
 
 class UserActionViewModel extends Equatable {
   final String id;
-  final String content;
-  final String comment;
-  final bool withComment;
+  final String title;
+  final String subtitle;
+  final bool withSubtitle;
   final UserActionStatus status;
   final String lastUpdate;
   final String creator;
@@ -21,9 +21,9 @@ class UserActionViewModel extends Equatable {
 
   UserActionViewModel({
     required this.id,
-    required this.content,
-    required this.comment,
-    required this.withComment,
+    required this.title,
+    required this.subtitle,
+    required this.withSubtitle,
     required this.status,
     required this.lastUpdate,
     required this.creator,
@@ -34,42 +34,36 @@ class UserActionViewModel extends Equatable {
   factory UserActionViewModel.create(UserAction userAction) {
     return UserActionViewModel(
       id: userAction.id,
-      content: userAction.content,
-      comment: userAction.comment,
-      withComment: userAction.comment.isNotEmpty,
+      title: userAction.content,
+      subtitle: userAction.comment,
+      withSubtitle: userAction.comment.isNotEmpty,
       status: userAction.status,
       lastUpdate: Strings.lastUpdateFormat(userAction.lastUpdate.toDay()),
       creator: _displayName(userAction.creator),
-      tag: _userActionTagViewModel(userAction),
+      tag: _userActionTagViewModel(userAction.status),
       withDeleteOption: userAction.creator is! ConseillerActionCreator,
     );
   }
 
   @override
-  List<Object?> get props => [id, content, comment, withComment, status, lastUpdate, creator, tag, withDeleteOption];
+  List<Object?> get props => [id, title, subtitle, withSubtitle, status, lastUpdate, creator, tag, withDeleteOption];
 }
 
-_displayName(UserActionCreator creator) {
-  if (creator is ConseillerActionCreator) {
-    return creator.name;
-  } else {
-    return Strings.you;
-  }
-}
+_displayName(UserActionCreator creator) => creator is ConseillerActionCreator ? creator.name : Strings.you;
 
-UserActionTagViewModel? _userActionTagViewModel(userAction) {
-  switch (userAction.status) {
+UserActionTagViewModel? _userActionTagViewModel(UserActionStatus status) {
+  switch (status) {
     case UserActionStatus.NOT_STARTED:
       return UserActionTagViewModel(
         title: Strings.actionToDo,
-        backgroundColor: AppColors.blueGrey,
-        textColor: AppColors.nightBlue,
+        backgroundColor: AppColors.accent1Lighten,
+        textColor: AppColors.accent1,
       );
     case UserActionStatus.IN_PROGRESS:
       return UserActionTagViewModel(
         title: Strings.actionInProgress,
-        backgroundColor: AppColors.purple,
-        textColor: Colors.white,
+        backgroundColor: AppColors.accent3Lighten,
+        textColor: AppColors.accent3,
       );
     case UserActionStatus.DONE:
       return null;
@@ -86,18 +80,6 @@ class UserActionTagViewModel extends Equatable {
     required this.backgroundColor,
     required this.textColor,
   });
-
-  @override
-  bool operator ==(Object other) =>
-      identical(this, other) ||
-      other is UserActionTagViewModel &&
-          runtimeType == other.runtimeType &&
-          title == other.title &&
-          backgroundColor == other.backgroundColor &&
-          textColor == other.textColor;
-
-  @override
-  int get hashCode => title.hashCode ^ backgroundColor.hashCode ^ textColor.hashCode;
 
   @override
   List<Object?> get props => [title, backgroundColor, textColor];

--- a/lib/widgets/cards/user_action_card.dart
+++ b/lib/widgets/cards/user_action_card.dart
@@ -1,26 +1,17 @@
 import 'package:flutter/material.dart';
-import 'package:pass_emploi_app/models/user_action.dart';
 import 'package:pass_emploi_app/ui/app_colors.dart';
 import 'package:pass_emploi_app/ui/margins.dart';
 import 'package:pass_emploi_app/ui/shadows.dart';
 import 'package:pass_emploi_app/ui/text_styles.dart';
 import 'package:pass_emploi_app/widgets/status_tag.dart';
 
-class EventCard extends StatelessWidget {
-  final VoidCallback onTap;
-  final String titre;
-  final String? sousTitre;
-  final UserActionStatus? statut;
-  final String? derniereModification;
+import '../../presentation/user_action_view_model.dart';
 
-  const EventCard({
-    Key? key,
-    required this.onTap,
-    required this.titre,
-    this.sousTitre,
-    this.statut,
-    this.derniereModification,
-  }) : super(key: key);
+class UserActionCard extends StatelessWidget {
+  final VoidCallback onTap;
+  final UserActionViewModel viewModel;
+
+  const UserActionCard({Key? key, required this.onTap, required this.viewModel}) : super(key: key);
 
   @override
   Widget build(BuildContext context) {
@@ -41,10 +32,10 @@ class EventCard extends StatelessWidget {
                 mainAxisSize: MainAxisSize.min,
                 crossAxisAlignment: CrossAxisAlignment.start,
                 children: [
-                  if (this.statut != null) _buildStatut(),
-                  Text(this.titre, style: TextStyles.textBaseBold),
-                  if (this.sousTitre != null && this.sousTitre!.isNotEmpty) _buildSousTitre(),
-                  if (this.derniereModification != null) _buildDerniereModification(this.derniereModification!),
+                  if (viewModel.tag != null) _buildStatut(viewModel.tag!),
+                  Text(viewModel.title, style: TextStyles.textBaseBold),
+                  if (viewModel.withSubtitle) _buildSousTitre(),
+                  _buildDerniereModification(),
                 ],
               ),
             ),
@@ -57,20 +48,18 @@ class EventCard extends StatelessWidget {
   Widget _buildSousTitre() {
     return Padding(
       padding: const EdgeInsets.only(top: Margins.spacing_s),
-      child: Text(this.sousTitre!, style: TextStyles.textSRegular(color: AppColors.contentColor)),
+      child: Text(viewModel.subtitle, style: TextStyles.textSRegular(color: AppColors.contentColor)),
     );
   }
 
-  Widget _buildStatut() {
+  Widget _buildStatut(UserActionTagViewModel viewModel) {
     return Padding(
       padding: const EdgeInsets.only(bottom: Margins.spacing_base),
-      child: StatutTag(
-        status: statut!,
-      ),
+      child: StatutTag(viewModel: viewModel),
     );
   }
 
-  Widget _buildDerniereModification(String label) {
+  Widget _buildDerniereModification() {
     return Column(
       crossAxisAlignment: CrossAxisAlignment.start,
       children: [
@@ -81,7 +70,7 @@ class EventCard extends StatelessWidget {
             color: AppColors.primaryLighten,
           ),
         ),
-        Text(label, style: TextStyles.textSRegular(color: AppColors.contentColor)),
+        Text(viewModel.lastUpdate, style: TextStyles.textSRegular(color: AppColors.contentColor)),
       ],
     );
   }

--- a/lib/widgets/status_tag.dart
+++ b/lib/widgets/status_tag.dart
@@ -1,46 +1,24 @@
 import 'package:flutter/material.dart';
-import 'package:pass_emploi_app/models/user_action.dart';
-import 'package:pass_emploi_app/ui/app_colors.dart';
-import 'package:pass_emploi_app/ui/strings.dart';
+import 'package:pass_emploi_app/presentation/user_action_view_model.dart';
 import 'package:pass_emploi_app/ui/text_styles.dart';
 
 class StatutTag extends StatelessWidget {
-  final UserActionStatus status;
+  final UserActionTagViewModel viewModel;
 
-  const StatutTag({
-    Key? key,
-    required this.status,
-  }) : super(key: key);
+  const StatutTag({Key? key, required this.viewModel}) : super(key: key);
 
   @override
   Widget build(BuildContext context) {
-    String label;
-    Color background;
-    Color textColor;
-    switch (this.status) {
-      case UserActionStatus.NOT_STARTED:
-        label = Strings.actionToDo;
-        background = AppColors.accent1Lighten;
-        textColor = AppColors.accent1;
-        break;
-      case UserActionStatus.IN_PROGRESS:
-        label = Strings.actionInProgress;
-        background = AppColors.accent3Lighten;
-        textColor = AppColors.accent3;
-        break;
-      default:
-        label = Strings.actionDone;
-        background = AppColors.accent2Lighten;
-        textColor = AppColors.accent2;
-        break;
-    }
     return Container(
       decoration: BoxDecoration(
-          borderRadius: BorderRadius.all(Radius.circular(40)), color: background, border: Border.all(color: textColor)),
+        borderRadius: BorderRadius.all(Radius.circular(40)),
+        color: viewModel.backgroundColor,
+        border: Border.all(color: viewModel.textColor),
+      ),
       padding: const EdgeInsets.symmetric(vertical: 4, horizontal: 16),
       child: Text(
-        label,
-        style: TextStyles.textSRegularWithColor(textColor),
+        viewModel.title,
+        style: TextStyles.textSRegularWithColor(viewModel.textColor),
       ),
     );
   }

--- a/lib/widgets/user_action_details_bottom_sheet.dart
+++ b/lib/widgets/user_action_details_bottom_sheet.dart
@@ -158,13 +158,13 @@ class _UserActionDetailsBottomSheetState extends State<UserActionDetailsBottomSh
           Padding(
             padding: const EdgeInsets.only(bottom: 8),
             child: Text(
-              widget.actionViewModel.content,
+              widget.actionViewModel.title,
               style: TextStyles.textSRegular(),
             ),
           ),
-          if (widget.actionViewModel.withComment)
+          if (widget.actionViewModel.withSubtitle)
             Text(
-              widget.actionViewModel.comment,
+              widget.actionViewModel.subtitle,
               style: TextStyles.textSRegular(),
             )
           else

--- a/test/presentation/user_action_list_page_view_model_test.dart
+++ b/test/presentation/user_action_list_page_view_model_test.dart
@@ -95,12 +95,14 @@ main() {
     final viewModel = UserActionListPageViewModel.create(store);
 
     // Then
-    expect(viewModel.items.length, 8);
+    expect(viewModel.items.length, 9);
     for (var i = 0; i < 5; ++i) {
       expect(viewModel.items[i] is UserActionListItemViewModel, isTrue);
       expect((viewModel.items[i] as UserActionListItemViewModel).viewModel.status != UserActionStatus.DONE, isTrue);
     }
-    for (var i = 5; i < 8; ++i) {
+    expect(viewModel.items[5] is UserActionListSubtitle, isTrue);
+    expect((viewModel.items[5] as UserActionListSubtitle).title, "Actions terminées");
+    for (var i = 6; i < 9; ++i) {
       expect(viewModel.items[i] is UserActionListItemViewModel, isTrue);
       expect((viewModel.items[i] as UserActionListItemViewModel).viewModel.status == UserActionStatus.DONE, isTrue);
     }
@@ -163,8 +165,10 @@ main() {
     final viewModel = UserActionListPageViewModel.create(store);
 
     // Then
-    expect(viewModel.items.length, 2);
-    for (var i = 0; i < 2; ++i) {
+    expect(viewModel.items.length, 3);
+    expect(viewModel.items[0] is UserActionListSubtitle, isTrue);
+    expect((viewModel.items[0] as UserActionListSubtitle).title, "Actions terminées");
+    for (var i = 1; i < 3; ++i) {
       expect(viewModel.items[i] is UserActionListItemViewModel, isTrue);
       expect((viewModel.items[i] as UserActionListItemViewModel).viewModel.status == UserActionStatus.DONE, isTrue);
     }

--- a/test/presentation/user_action_view_model_test.dart
+++ b/test/presentation/user_action_view_model_test.dart
@@ -1,4 +1,3 @@
-import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:pass_emploi_app/models/user_action.dart';
 import 'package:pass_emploi_app/models/user_action_creator.dart';
@@ -84,8 +83,8 @@ main() {
         viewModel.tag,
         UserActionTagViewModel(
           title: Strings.actionToDo,
-          backgroundColor: AppColors.blueGrey,
-          textColor: AppColors.nightBlue,
+          backgroundColor: AppColors.accent1Lighten,
+          textColor: AppColors.accent1,
         ));
   });
 
@@ -109,8 +108,8 @@ main() {
         viewModel.tag,
         UserActionTagViewModel(
           title: Strings.actionInProgress,
-          backgroundColor: AppColors.purple,
-          textColor: Colors.white,
+          backgroundColor: AppColors.accent3Lighten,
+          textColor: AppColors.accent3,
         ));
   });
 


### PR DESCRIPTION
Il y a du avoir un écart entre les maquette de refonte UI, et celles d'avant. Du coup, la feature que l'on avait fait 2 semaines avant avait disparu. Je m'en suis très bien sorti avec l'historique git.
Par contre, j'en ai profité pour :
* Utiliser le ViewModel existant pour le widget du tag
* Utiliser le "super" ViewModel plutôt que les N param pour le widget de l'action
* Renommer `EventCard` > `UserActionCard` : de mémoire, j'avais fait ce retour en MR, s'il n'a pas été pris par choix, dites-le moi et je revert le renommage.