### PR TITLE
[BUILD] 400 - Suppression des logs en production

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -19,6 +19,7 @@ Ce document liste les différentes pratiques de dev mises en place sur le projet
     * [Expression body vs block body](#expression-body-vs-block-body)
     * [Les arguments nommés](#les-arguments-nommés)
     * [Déclarations des resources](#déclarations-des-resources)
+    * [Log de messages](#log-de-messages)
 * [Gestion des cas non nominaux](#gestion-des-cas-non-nominaux)
     * [Utiliser les types nullables pour les cas simples](#utiliser-les-types-nullables-pour-les-cas-simples)
     * [Utiliser des objets pour les cas plus complexe](#utiliser-des-objets-pour-les-cas-plus-complexe)
@@ -95,7 +96,10 @@ Afin de conserver à part toutes les ressources du projet (wordings, assets…) 
 logging ne sont pas concernés. 
 * Toutes les images affichées dans l'application doivent être déclarées dans le fichier `drawables.dart`.
 
-
+## Log de messages
+Un audit de sécurité nous a fait constater que les messages logués, même avec la méthode `debugPrint()`,
+apparaissaient en production. Pour éviter un tel comportement, les logs doivent se faire via la classe
+[Log](lib/utils/log.dart), afin de s'assurer qu'ils ne s'affichent qu'en debug.
 
 # Gestion des cas non nominaux
 Le langage Dart propose des exceptions, mais il n'y a pas moyen de déclarer qu'une méthode est susceptible d'en lancer 

--- a/analysis_options.yaml
+++ b/analysis_options.yaml
@@ -17,6 +17,7 @@ analyzer:
     prefer_final_locals: error
     sort_child_properties_last: error
     use_decorated_box: error
+    avoid_print: error
     constant_identifier_names: ignore
     prefer_const_constructors: ignore
     prefer_const_literals_to_create_immutables: ignore

--- a/lib/auth/auth_wrapper.dart
+++ b/lib/auth/auth_wrapper.dart
@@ -1,10 +1,10 @@
-import 'package:flutter/cupertino.dart';
 import 'package:flutter/services.dart';
 import 'package:flutter_appauth/flutter_appauth.dart';
 import 'package:pass_emploi_app/auth/auth_logout_request.dart';
 import 'package:pass_emploi_app/auth/auth_refresh_token_request.dart';
 import 'package:pass_emploi_app/auth/auth_token_request.dart';
 import 'package:pass_emploi_app/auth/auth_token_response.dart';
+import 'package:pass_emploi_app/utils/log.dart';
 
 class AuthWrapper {
   final FlutterAppAuth _appAuth;
@@ -79,7 +79,7 @@ class AuthWrapper {
       } else if (e.code == "token_failed") {
         throw AuthWrapperRefreshTokenExpiredException();
       } else {
-        debugPrint(e.toString());
+        Log.w(e.toString());
         rethrow;
       }
     }
@@ -93,7 +93,7 @@ class AuthWrapper {
         issuer: request.issuer,
       ));
     } catch (e) {
-      debugPrint(e.toString());
+      Log.w(e.toString());
       throw AuthWrapperLogoutException();
     }
   }

--- a/lib/auth/firebase_auth_wrapper.dart
+++ b/lib/auth/firebase_auth_wrapper.dart
@@ -1,5 +1,5 @@
 import 'package:firebase_auth/firebase_auth.dart';
-import 'package:flutter/foundation.dart';
+import 'package:pass_emploi_app/utils/log.dart';
 
 class FirebaseAuthWrapper {
   Future<bool> signInWithCustomToken(String token) async {
@@ -7,7 +7,7 @@ class FirebaseAuthWrapper {
       await FirebaseAuth.instance.signInWithCustomToken(token);
       return true;
     } catch (e) {
-      debugPrint(e.toString());
+      Log.w(e.toString());
     }
     return false;
   }

--- a/lib/configuration/configuration.dart
+++ b/lib/configuration/configuration.dart
@@ -1,8 +1,8 @@
 import 'dart:convert';
 
-import 'package:flutter/foundation.dart';
 import 'package:flutter_dotenv/flutter_dotenv.dart';
 import 'package:package_info/package_info.dart';
+import 'package:pass_emploi_app/utils/log.dart';
 
 enum Flavor { STAGING, PROD }
 
@@ -36,7 +36,7 @@ class Configuration {
   static Future<Configuration> build() async {
     final packageName = (await PackageInfo.fromPlatform()).packageName;
     final flavor = packageName.contains("staging") ? Flavor.STAGING : Flavor.PROD;
-    debugPrint("FLAVOR = $flavor");
+    Log.i("Flavor = $flavor");
     await loadEnvironmentVariables(flavor);
     final serverBaseUrl = getOrThrow('SERVER_BASE_URL');
     final matomoBaseUrl = getOrThrow('MATOMO_BASE_URL');

--- a/lib/crashlytics/crashlytics.dart
+++ b/lib/crashlytics/crashlytics.dart
@@ -1,7 +1,7 @@
 import 'dart:io';
 
 import 'package:firebase_crashlytics/firebase_crashlytics.dart';
-import 'package:flutter/foundation.dart';
+import 'package:pass_emploi_app/utils/log.dart';
 
 abstract class Crashlytics {
   void setCustomKey(String key, String value);
@@ -22,7 +22,7 @@ class CrashlyticsWithFirebase extends Crashlytics {
   @override
   void recordNonNetworkException(dynamic exception, StackTrace stack, [Uri? failingEndpoint]) {
     final logPrefix = failingEndpoint != null ? 'Exception on $failingEndpoint' : 'Exception';
-    debugPrint('$logPrefix: $exception');
+    Log.e('$logPrefix: $exception');
     if (exception is SocketException) return;
     FirebaseCrashlytics.instance.recordError(
       exception,

--- a/lib/network/logging_interceptor.dart
+++ b/lib/network/logging_interceptor.dart
@@ -1,16 +1,16 @@
-import 'package:flutter/foundation.dart';
 import 'package:http_interceptor/http_interceptor.dart';
+import 'package:pass_emploi_app/utils/log.dart';
 
 class LoggingInterceptor implements InterceptorContract {
   @override
   Future<RequestData> interceptRequest({required RequestData data}) async {
-    debugPrint(data.toString());
+    Log.i(data.toString());
     return data;
   }
 
   @override
   Future<ResponseData> interceptResponse({required ResponseData data}) async {
-    debugPrint(data.toString());
+    Log.i(data.toString());
     return data;
   }
 }

--- a/lib/pages/entree_page.dart
+++ b/lib/pages/entree_page.dart
@@ -26,7 +26,6 @@ class EntreePage extends TraceableStatelessWidget {
   Widget build(BuildContext context) {
     final screenWidth = MediaQuery.of(context).size.width;
     final screenHeight = MediaQuery.of(context).size.height;
-    debugPrint("h = $screenHeight");
     return Scaffold(
       body: Stack(
         children: [

--- a/lib/push/firebase_push_notification_manager.dart
+++ b/lib/push/firebase_push_notification_manager.dart
@@ -2,14 +2,14 @@ import 'dart:async';
 import 'dart:io';
 
 import 'package:firebase_messaging/firebase_messaging.dart';
-import 'package:flutter/foundation.dart';
 import 'package:flutter_local_notifications/flutter_local_notifications.dart';
 import 'package:pass_emploi_app/push/push_notification_manager.dart';
 import 'package:pass_emploi_app/redux/states/app_state.dart';
+import 'package:pass_emploi_app/utils/log.dart';
 import 'package:redux/redux.dart';
 
 Future<void> _firebaseMessagingBackgroundHandler(RemoteMessage message) async {
-  debugPrint("Handling a background message: ${message.messageId}");
+  Log.d("Handling a background message: ${message.messageId}");
 }
 
 class FirebasePushNotificationManager extends PushNotificationManager {
@@ -25,7 +25,7 @@ class FirebasePushNotificationManager extends PushNotificationManager {
   @override
   Future<String?> getToken() async {
     String? token = await _firebaseMessaging.getToken();
-    debugPrint("FirebaseMessaging token: $token");
+    Log.d("FirebaseMessaging token: $token");
     return token;
   }
 
@@ -35,7 +35,7 @@ class FirebasePushNotificationManager extends PushNotificationManager {
       badge: true,
       sound: true,
     );
-    debugPrint('User granted permission: ${settings.authorizationStatus}');
+    Log.d('User granted permission: ${settings.authorizationStatus}');
   }
 
   Future<void> _createHighImportanceAndroidChannel() async {

--- a/lib/redux/middlewares/action_logging_middleware.dart
+++ b/lib/redux/middlewares/action_logging_middleware.dart
@@ -1,12 +1,11 @@
-import 'dart:developer';
-
 import 'package:pass_emploi_app/redux/states/app_state.dart';
+import 'package:pass_emploi_app/utils/log.dart';
 import 'package:redux/redux.dart';
 
 class ActionLoggingMiddleware extends MiddlewareClass<AppState> {
   @override
   call(Store<AppState> store, action, NextDispatcher next) {
-    log(_stripActionName(action), name: "ACTIONS");
+    Log.d("ACTIONS" + _stripActionName(action));
     next(action);
   }
 

--- a/lib/repositories/chat_repository.dart
+++ b/lib/repositories/chat_repository.dart
@@ -1,11 +1,11 @@
 import 'dart:async';
 
 import 'package:cloud_firestore/cloud_firestore.dart';
-import 'package:flutter/foundation.dart';
 import 'package:pass_emploi_app/crashlytics/crashlytics.dart';
 import 'package:pass_emploi_app/models/conseiller_messages_info.dart';
 import 'package:pass_emploi_app/models/message.dart';
 import 'package:pass_emploi_app/repositories/crypto/chat_crypto.dart';
+import 'package:pass_emploi_app/utils/log.dart';
 
 const String _collectionPath = "chat";
 
@@ -67,7 +67,7 @@ class ChatRepository {
               'seenByConseiller': false,
             });
         })
-        .then((value) => debugPrint("New message sent $message && chat status updated"))
+        .then((value) => Log.d("New message sent $message && chat status updated"))
         .catchError((e, StackTrace stack) => _crashlytics.recordNonNetworkException(e, stack));
   }
 
@@ -81,7 +81,7 @@ class ChatRepository {
           'newConseillerMessageCount': 0,
           'lastJeuneReading': seenByJeuneAt,
         })
-        .then((value) => debugPrint("Last message seen updated"))
+        .then((value) => Log.d("Last message seen updated"))
         .catchError((e, StackTrace stack) => _crashlytics.recordNonNetworkException(e, stack));
   }
 

--- a/lib/utils/log.dart
+++ b/lib/utils/log.dart
@@ -1,0 +1,46 @@
+import 'dart:io';
+
+import 'package:flutter/foundation.dart';
+import 'package:logger/logger.dart';
+
+class Log {
+  static final _normalLogger = Logger(
+    filter: CustomLogFilter(),
+    printer: PrettyPrinter(methodCount: 0),
+  );
+
+  static final _exceptionLogger = Logger(
+    filter: CustomLogFilter(),
+    printer: PrettyPrinter(methodCount: 8),
+  );
+
+  Log._();
+
+  /// Log a message at level [Level.debug].
+  static void d(dynamic message, [dynamic error, StackTrace? stackTrace]) {
+    _normalLogger.d(message, error, stackTrace);
+  }
+
+  /// Log a message at level [Level.info].
+  static void i(dynamic message, [dynamic error, StackTrace? stackTrace]) {
+    _normalLogger.i(message, error, stackTrace);
+  }
+
+  /// Log a message at level [Level.warning].
+  static void w(dynamic message, [dynamic error, StackTrace? stackTrace]) {
+    _exceptionLogger.w(message, error, stackTrace);
+  }
+
+  /// Log a message at level [Level.error].
+  static void e(dynamic message, [dynamic error, StackTrace? stackTrace]) {
+    _exceptionLogger.e(message, error, stackTrace);
+  }
+}
+
+class CustomLogFilter extends LogFilter {
+  @override
+  bool shouldLog(LogEvent event) {
+    final flutterTest = Platform.environment.containsKey('FLUTTER_TEST');
+    return kDebugMode && !flutterTest;
+  }
+}

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -436,6 +436,13 @@ packages:
       url: "https://pub.dartlang.org"
     source: hosted
     version: "1.0.1"
+  logger:
+    dependency: "direct main"
+    description:
+      name: logger
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "1.1.0"
   logging:
     dependency: transitive
     description:
@@ -906,5 +913,5 @@ packages:
     source: hosted
     version: "5.3.1"
 sdks:
-  dart: "2.16.1"
+  dart: "2.16.0"
   flutter: ">=2.10.0"

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -28,6 +28,7 @@ dependencies:
   intl: '0.17.0'
   collection: '1.15.0'
   equatable: '2.0.3'
+  logger: '1.1.0'
   # Firebase
   firebase_core: '1.10.6'
   firebase_crashlytics: '2.4.4'

--- a/test/doubles/dummies.dart
+++ b/test/doubles/dummies.dart
@@ -1,4 +1,3 @@
-import 'package:flutter/material.dart';
 import 'package:flutter_appauth/flutter_appauth.dart';
 import 'package:http/http.dart';
 import 'package:http/testing.dart';
@@ -90,9 +89,7 @@ class DummyCrashlytics extends Crashlytics {
   void setCustomKey(String key, value) {}
 
   @override
-  void recordNonNetworkException(dynamic exception, StackTrace stack, [Uri? failingEndpoint]) {
-    debugPrint(exception.toString());
-  }
+  void recordNonNetworkException(dynamic exception, StackTrace stack, [Uri? failingEndpoint]) {}
 }
 
 class DummyOffreEmploiRepository extends OffreEmploiRepository {


### PR DESCRIPTION
Comme évoqué sur Mattermost, `debugPrint` ne fait en fait pas du tout ça 😅.
J'en ai profité pour ajouter une lib de Logger dont je trouve le rendu plutôt quali.
Par contre, 

1. Il reste des logs des libs `FirebaseAuth` et `FIrestore` natives Android => `FirebaseAuth: Notifying id token listeners about user ( FLHPT ).` . Pas fou car l'ID est toujours loggé, mais c'est assez long à faire… Je pense que ça peut passer comme ça (j'ai mis un message aux PO dans le ticket à cet effet).
2. J'aurais aimé mettre en place une règle lint custom, pour éviter les `debugPrint()`, mais ça parrait assez long à faire… En conséquence j'ai juste mis à jour le `CONTRIBUTING.md.`