### PR TITLE
[FEAT] 358 - Analytics : les liens sortant sont comptabilisés comme des pages internes

### DIFF
--- a/lib/pages/choix_organisme_page.dart
+++ b/lib/pages/choix_organisme_page.dart
@@ -94,7 +94,7 @@ class ChoixOrganismePage extends TraceableStatelessWidget {
                           color: Colors.transparent,
                           child: InkWell(
                             onTap: () {
-                              MatomoTracker.trackScreenWithName(noOrganismeLink, AnalyticsScreenNames.choixOrganisme);
+                              MatomoTracker.trackOutlink(noOrganismeLink);
                               launch(noOrganismeLink);
                             },
                             child: Padding(

--- a/lib/pages/entree_page.dart
+++ b/lib/pages/entree_page.dart
@@ -132,7 +132,7 @@ class Link extends StatelessWidget {
       color: Colors.transparent,
       child: InkWell(
         onTap: () {
-          MatomoTracker.trackScreenWithName(link, AnalyticsScreenNames.entree);
+          MatomoTracker.trackOutlink(link);
           launch(link);
         },
         child: Wrap(

--- a/lib/pages/profil_page.dart
+++ b/lib/pages/profil_page.dart
@@ -145,7 +145,7 @@ class ProfilPage extends TraceableStatelessWidget {
   }
 
   void _launchAndTrackExternalLink(String link) {
-    MatomoTracker.trackScreenWithName(link, AnalyticsScreenNames.profil);
+    MatomoTracker.trackOutlink(link);
     launch(link);
   }
 

--- a/lib/widgets/cards/boite_a_outils_card.dart
+++ b/lib/widgets/cards/boite_a_outils_card.dart
@@ -1,6 +1,5 @@
 import 'package:flutter/material.dart';
 import 'package:matomo/matomo.dart';
-import 'package:pass_emploi_app/analytics/analytics_constants.dart';
 import 'package:pass_emploi_app/models/outil.dart';
 import 'package:pass_emploi_app/ui/app_colors.dart';
 import 'package:pass_emploi_app/ui/margins.dart';
@@ -26,7 +25,7 @@ class BoiteAOutilsCard extends StatelessWidget {
       child: InkWell(
         customBorder: roundedCornerShape,
         onTap: () {
-          MatomoTracker.trackScreenWithName(outil.urlRedirect, AnalyticsScreenNames.toolbox);
+          MatomoTracker.trackOutlink(outil.urlRedirect);
           launch(outil.urlRedirect);
         },
         child: Column(

--- a/lib/widgets/text_with_clickable_links.dart
+++ b/lib/widgets/text_with_clickable_links.dart
@@ -19,7 +19,7 @@ class TextWithClickableLinks extends StatelessWidget {
       linkStyle: linkStyle ?? TextStyles.externalLink,
       onOpen: (link) {
         final String baseUrl = Uri.parse(link.url).origin;
-        MatomoTracker.trackScreenWithName(baseUrl, baseUrl);
+        MatomoTracker.trackOutlink(baseUrl);
         launch(link.url);
       },
       options: LinkifyOptions(

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -468,8 +468,8 @@ packages:
     dependency: "direct main"
     description:
       path: "."
-      ref: HEAD
-      resolved-ref: b4a370276f7ac4f0c31623bf954b3c4f3f78cd6f
+      ref: "feat/add-outlink-support"
+      resolved-ref: "745ccc814561e4aeaeec9f867e24d32e21e623c6"
       url: "https://github.com/BonnetM/dart-matomo.git"
     source: git
     version: "1.1.0"

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -41,7 +41,9 @@ dependencies:
   google_fonts: '2.1.0'
   # Analytics
   matomo:
-    git: https://github.com/BonnetM/dart-matomo.git
+    git:
+      url: https://github.com/BonnetM/dart-matomo.git
+      ref: feat/add-outlink-support
 
   encrypt: '5.0.1'
   smooth_page_indicator: ^1.0.0+2


### PR DESCRIPTION
Pour info, la modif sur le fork matomo : https://github.com/BonnetM/dart-matomo/commit/745ccc814561e4aeaeec9f867e24d32e21e623c6