### PR TITLE
tech: ensure flutter analyse fails when needed and fix issues

### DIFF
--- a/analysis_options.yaml
+++ b/analysis_options.yaml
@@ -24,4 +24,3 @@ analyzer:
     missing_return: error
     dead_code: error
     unused_element: error
-    prefer_double_quotes: error

--- a/analysis_options.yaml
+++ b/analysis_options.yaml
@@ -1,6 +1,19 @@
 # Doc can be [found here](https://dart.dev/guides/language/analysis-options)
 include:
   package:flutter_lints/flutter.yaml
+linter:
+  rules:
+    always_declare_return_types: true
+    prefer_final_fields: true
+    prefer_final_locals: true
+    sort_child_properties_last: true
+    use_decorated_box: true
+    avoid_print: true
+    constant_identifier_names: false
+    prefer_const_constructors: false
+    prefer_const_literals_to_create_immutables: false
+    prefer_const_constructors_in_immutables: false
+    use_key_in_widget_constructors: false
 
 analyzer:
   exclude: [ build/** ]
@@ -11,15 +24,4 @@ analyzer:
     missing_return: error
     dead_code: error
     unused_element: error
-    always_declare_return_types: error
     prefer_double_quotes: error
-    prefer_final_fields: error
-    prefer_final_locals: error
-    sort_child_properties_last: error
-    use_decorated_box: error
-    avoid_print: error
-    constant_identifier_names: ignore
-    prefer_const_constructors: ignore
-    prefer_const_literals_to_create_immutables: ignore
-    prefer_const_constructors_in_immutables: ignore
-    use_key_in_widget_constructors: ignore

--- a/lib/auth/authenticator.dart
+++ b/lib/auth/authenticator.dart
@@ -62,7 +62,7 @@ class Authenticator {
     if (refreshToken == null) return RefreshTokenStatus.USER_NOT_LOGGED_IN;
 
     try {
-      AuthTokenResponse response = await _authWrapper.refreshToken(
+      final AuthTokenResponse response = await _authWrapper.refreshToken(
         AuthRefreshTokenRequest(
           _configuration.authClientId,
           _configuration.authLoginRedirectUrl,

--- a/lib/features/chat/init/chat_initializer_middleware.dart
+++ b/lib/features/chat/init/chat_initializer_middleware.dart
@@ -15,7 +15,7 @@ class ChatInitializerMiddleware extends MiddlewareClass<AppState> {
   ChatInitializerMiddleware(this._repository, this._firebaseAuthWrapper, this._chatCrypto);
 
   @override
-  call(Store<AppState> store, action, NextDispatcher next) async {
+  void call(Store<AppState> store, action, NextDispatcher next) async {
     if (action is LoginSuccessAction) {
       if (store.state.deepLinkState.deepLink == DeepLink.ROUTE_TO_CHAT) {
         await _initializeChatFirstThenDispatchLogin(action, next, store);

--- a/lib/features/chat/messages/chat_middleware.dart
+++ b/lib/features/chat/messages/chat_middleware.dart
@@ -15,7 +15,7 @@ class ChatMiddleware extends MiddlewareClass<AppState> {
   ChatMiddleware(this._repository);
 
   @override
-  call(Store<AppState> store, action, NextDispatcher next) async {
+  void call(Store<AppState> store, action, NextDispatcher next) async {
     next(action);
     final loginState = store.state.loginState;
     if (loginState is LoginSuccessState) {

--- a/lib/features/chat/status/chat_status_middleware.dart
+++ b/lib/features/chat/status/chat_status_middleware.dart
@@ -14,7 +14,7 @@ class ChatStatusMiddleware extends MiddlewareClass<AppState> {
   ChatStatusMiddleware(this._repository);
 
   @override
-  call(Store<AppState> store, action, NextDispatcher next) async {
+  void call(Store<AppState> store, action, NextDispatcher next) async {
     next(action);
     final loginState = store.state.loginState;
     if (loginState is LoginSuccessState && action is SubscribeToChatStatusAction) {

--- a/lib/features/favori/ids/favori_ids_middleware.dart
+++ b/lib/features/favori/ids/favori_ids_middleware.dart
@@ -11,7 +11,7 @@ class FavoriIdsMiddleware<T> extends MiddlewareClass<AppState> {
   FavoriIdsMiddleware(this._repository);
 
   @override
-  call(Store<AppState> store, action, NextDispatcher next) async {
+  void call(Store<AppState> store, action, NextDispatcher next) async {
     next(action);
     if (action is LoginSuccessAction) {
       final ids = await _repository.getFavorisId(action.user.id);

--- a/lib/features/favori/list/favori_list_middleware.dart
+++ b/lib/features/favori/list/favori_list_middleware.dart
@@ -10,7 +10,7 @@ class FavoriListMiddleware<T> extends MiddlewareClass<AppState> {
   FavoriListMiddleware(this._repository);
 
   @override
-  call(Store<AppState> store, action, NextDispatcher next) async {
+  void call(Store<AppState> store, action, NextDispatcher next) async {
     next(action);
     final loginState = store.state.loginState;
     if (action is FavoriListRequestAction<T> && loginState is LoginSuccessState) {

--- a/lib/features/favori/update/favori_update_middleware.dart
+++ b/lib/features/favori/update/favori_update_middleware.dart
@@ -11,7 +11,7 @@ class FavoriUpdateMiddleware<T> extends MiddlewareClass<AppState> {
   FavoriUpdateMiddleware(this._repository, this._dataFromIdExtractor);
 
   @override
-  call(Store<AppState> store, action, NextDispatcher next) async {
+  void call(Store<AppState> store, action, NextDispatcher next) async {
     next(action);
     final loginState = store.state.loginState;
     if (action is FavoriUpdateRequestAction<T> && loginState is LoginSuccessState) {

--- a/lib/features/immersion/details/immersion_details_middleware.dart
+++ b/lib/features/immersion/details/immersion_details_middleware.dart
@@ -12,7 +12,7 @@ class ImmersionDetailsMiddleware extends MiddlewareClass<AppState> {
   ImmersionDetailsMiddleware(this._repository);
 
   @override
-  call(Store<AppState> store, dynamic action, NextDispatcher next) async {
+  void call(Store<AppState> store, dynamic action, NextDispatcher next) async {
     next(action);
     if (action is ImmersionDetailsRequestAction) {
       store.dispatch(ImmersionDetailsLoadingAction());

--- a/lib/features/immersion/list/immersion_list_middleware.dart
+++ b/lib/features/immersion/list/immersion_list_middleware.dart
@@ -13,7 +13,7 @@ class ImmersionListMiddleware extends MiddlewareClass<AppState> {
   ImmersionListMiddleware(this._repository);
 
   @override
-  call(Store<AppState> store, action, NextDispatcher next) async {
+  void call(Store<AppState> store, action, NextDispatcher next) async {
     next(action);
     final loginState = store.state.loginState;
     final parametersState = store.state.immersionSearchParametersState;

--- a/lib/features/immersion/saved_search/immersion_saved_search_middleware.dart
+++ b/lib/features/immersion/saved_search/immersion_saved_search_middleware.dart
@@ -11,7 +11,7 @@ class ImmersionSavedSearchMiddleware extends MiddlewareClass<AppState> {
   ImmersionSavedSearchMiddleware(this._repository);
 
   @override
-  call(Store<AppState> store, action, NextDispatcher next) async {
+  void call(Store<AppState> store, action, NextDispatcher next) async {
     next(action);
     final loginState = store.state.loginState;
     if (loginState is LoginSuccessState) {

--- a/lib/features/location/search_location_middleware.dart
+++ b/lib/features/location/search_location_middleware.dart
@@ -11,7 +11,7 @@ class SearchLocationMiddleware extends MiddlewareClass<AppState> {
   SearchLocationMiddleware(this._repository);
 
   @override
-  call(Store<AppState> store, action, NextDispatcher next) async {
+  void call(Store<AppState> store, action, NextDispatcher next) async {
     next(action);
     if (action is SearchLocationRequestAction) {
       final List<Location> locations = [];

--- a/lib/features/login/login_middleware.dart
+++ b/lib/features/login/login_middleware.dart
@@ -15,7 +15,7 @@ class LoginMiddleware extends MiddlewareClass<AppState> {
   LoginMiddleware(this._authenticator, this._firebaseAuthWrapper);
 
   @override
-  call(Store<AppState> store, action, NextDispatcher next) async {
+  void call(Store<AppState> store, action, NextDispatcher next) async {
     next(action);
     if (action is BootstrapAction) {
       _checkIfUserIsLoggedIn(store);
@@ -37,7 +37,7 @@ class LoginMiddleware extends MiddlewareClass<AppState> {
 
   void _logUser(Store<AppState> store, RequestLoginMode mode) async {
     store.dispatch(LoginLoadingAction());
-    var authenticatorResponse = await _authenticator.login(_getAuthenticationMode(mode));
+    final authenticatorResponse = await _authenticator.login(_getAuthenticationMode(mode));
     if (authenticatorResponse == AuthenticatorResponse.SUCCESS) {
       _dispatchLoginSuccess(store);
     } else if (authenticatorResponse == AuthenticatorResponse.FAILURE) {

--- a/lib/features/login/pole_emploi/pole_emploi_auth_middleware.dart
+++ b/lib/features/login/pole_emploi/pole_emploi_auth_middleware.dart
@@ -12,7 +12,7 @@ class PoleEmploiAuthMiddleware extends MiddlewareClass<AppState> {
   PoleEmploiAuthMiddleware(this._repository, this._tokenRepository);
 
   @override
-  call(Store<AppState> store, action, NextDispatcher next) async {
+  void call(Store<AppState> store, action, NextDispatcher next) async {
     next(action);
     if (_shouldGetToken(action)) {
       final token = await _repository.getPoleEmploiToken();

--- a/lib/features/metier/search_metier_middleware.dart
+++ b/lib/features/metier/search_metier_middleware.dart
@@ -11,7 +11,7 @@ class SearchMetierMiddleware extends MiddlewareClass<AppState> {
   SearchMetierMiddleware(this._repository);
 
   @override
-  call(Store<AppState> store, action, NextDispatcher next) async {
+  void call(Store<AppState> store, action, NextDispatcher next) async {
     next(action);
     if (action is SearchMetierRequestAction) {
       final input = action.input;

--- a/lib/features/offre_emploi/details/offre_emploi_details_middleware.dart
+++ b/lib/features/offre_emploi/details/offre_emploi_details_middleware.dart
@@ -11,7 +11,7 @@ class OffreEmploiDetailsMiddleware extends MiddlewareClass<AppState> {
   OffreEmploiDetailsMiddleware(this._repository);
 
   @override
-  call(Store<AppState> store, dynamic action, NextDispatcher next) async {
+  void call(Store<AppState> store, dynamic action, NextDispatcher next) async {
     next(action);
     if (action is OffreEmploiDetailsRequestAction) {
       store.dispatch(OffreEmploiDetailsLoadingAction());
@@ -25,7 +25,7 @@ class OffreEmploiDetailsMiddleware extends MiddlewareClass<AppState> {
   }
 
   void _dispatchIncompleteDataOrError<T>(Store<AppState> store, OffreDetailsResponse<T> result, String offreId) {
-    var favorisState = store.state.offreEmploiFavorisState;
+    final favorisState = store.state.offreEmploiFavorisState;
     if (result.isOffreNotFound &&
         favorisState is FavoriListLoadedState<OffreEmploi> &&
         favorisState.data != null &&

--- a/lib/features/offre_emploi/saved_search/offre_emploi_saved_search_middleware.dart
+++ b/lib/features/offre_emploi/saved_search/offre_emploi_saved_search_middleware.dart
@@ -12,7 +12,7 @@ class OffreEmploiSavedSearchMiddleware extends MiddlewareClass<AppState> {
   OffreEmploiSavedSearchMiddleware(this._repository);
 
   @override
-  call(Store<AppState> store, dynamic action, NextDispatcher next) async {
+  void call(Store<AppState> store, dynamic action, NextDispatcher next) async {
     next(action);
     final loginState = store.state.loginState;
     if (loginState is LoginSuccessState) {

--- a/lib/features/offre_emploi/search/offre_emploi_search_middleware.dart
+++ b/lib/features/offre_emploi/search/offre_emploi_search_middleware.dart
@@ -15,14 +15,14 @@ class OffreEmploiMiddleware extends MiddlewareClass<AppState> {
   OffreEmploiMiddleware(this._repository);
 
   @override
-  call(Store<AppState> store, dynamic action, NextDispatcher next) async {
+  void call(Store<AppState> store, dynamic action, NextDispatcher next) async {
     next(action);
     final loginState = store.state.loginState;
     final parametersState = store.state.offreEmploiSearchParametersState;
     final previousResultsState = store.state.offreEmploiListState;
     final offreEmploiSearchState = store.state.offreEmploiSearchState;
     if (loginState is LoginSuccessState) {
-      var userId = loginState.user.id;
+      final userId = loginState.user.id;
       if (action is OffreEmploiSearchRequestAction) {
         _search(
           store: store,

--- a/lib/features/push/register_push_notification_token_middleware.dart
+++ b/lib/features/push/register_push_notification_token_middleware.dart
@@ -9,7 +9,7 @@ class RegisterPushNotificationTokenMiddleware extends MiddlewareClass<AppState> 
   RegisterPushNotificationTokenMiddleware(this._repository);
 
   @override
-  call(Store<AppState> store, action, NextDispatcher next) {
+  void call(Store<AppState> store, action, NextDispatcher next) {
     next(action);
     if (action is LoginSuccessAction) {
       _repository.registerToken(action.user.id);

--- a/lib/features/rendezvous/rendezvous_middleware.dart
+++ b/lib/features/rendezvous/rendezvous_middleware.dart
@@ -10,7 +10,7 @@ class RendezvousMiddleware extends MiddlewareClass<AppState> {
   RendezvousMiddleware(this._repository);
 
   @override
-  call(Store<AppState> store, action, NextDispatcher next) async {
+  void call(Store<AppState> store, action, NextDispatcher next) async {
     next(action);
     final loginState = store.state.loginState;
     if (loginState is LoginSuccessState && action is RendezvousRequestAction) {

--- a/lib/features/saved_search/create/saved_search_create_middleware.dart
+++ b/lib/features/saved_search/create/saved_search_create_middleware.dart
@@ -11,7 +11,7 @@ abstract class SavedSearchCreateMiddleware<T> extends MiddlewareClass<AppState> 
   SavedSearchCreateMiddleware(this._repository);
 
   @override
-  call(Store<AppState> store, action, NextDispatcher next) async {
+  void call(Store<AppState> store, action, NextDispatcher next) async {
     next(action);
     final loginState = store.state.loginState;
     if (action is SavedSearchCreateRequestAction<T> && loginState is LoginSuccessState) {

--- a/lib/features/saved_search/delete/saved_search_delete_middleware.dart
+++ b/lib/features/saved_search/delete/saved_search_delete_middleware.dart
@@ -10,7 +10,7 @@ class SavedSearchDeleteMiddleware extends MiddlewareClass<AppState> {
   SavedSearchDeleteMiddleware(this.repository);
 
   @override
-  call(Store<AppState> store, action, NextDispatcher next) async {
+  void call(Store<AppState> store, action, NextDispatcher next) async {
     next(action);
     final loginState = store.state.loginState;
     if (loginState is LoginSuccessState && action is SavedSearchDeleteRequestAction) {

--- a/lib/features/saved_search/get/saved_search_get_middleware.dart
+++ b/lib/features/saved_search/get/saved_search_get_middleware.dart
@@ -15,7 +15,7 @@ class SavedSearchGetMiddleware extends MiddlewareClass<AppState> {
   SavedSearchGetMiddleware(this._repository);
 
   @override
-  call(Store<AppState> store, action, NextDispatcher next) async {
+  void call(Store<AppState> store, action, NextDispatcher next) async {
     next(action);
     final loginState = store.state.loginState;
     if (action is SavedSearchGetAction && loginState is LoginSuccessState) {

--- a/lib/features/saved_search/init/saved_search_initialize_middleware.dart
+++ b/lib/features/saved_search/init/saved_search_initialize_middleware.dart
@@ -10,7 +10,7 @@ import '../../../models/saved_search/saved_search_extractors.dart';
 
 class SavedSearchInitializeMiddleware extends MiddlewareClass<AppState> {
   @override
-  call(Store<AppState> store, action, NextDispatcher next) {
+  void call(Store<AppState> store, action, NextDispatcher next) {
     next(action);
     final loginState = store.state.loginState;
     if (action is SaveSearchInitializeAction<OffreEmploiSavedSearch> && loginState is LoginSuccessState) {

--- a/lib/features/saved_search/list/saved_search_list_middleware.dart
+++ b/lib/features/saved_search/list/saved_search_list_middleware.dart
@@ -10,7 +10,7 @@ class SavedSearchListMiddleware extends MiddlewareClass<AppState> {
   SavedSearchListMiddleware(this._repository);
 
   @override
-  call(Store<AppState> store, action, NextDispatcher next) async {
+  void call(Store<AppState> store, action, NextDispatcher next) async {
     next(action);
     final loginState = store.state.loginState;
     if (loginState is LoginSuccessState && action is SavedSearchListRequestAction) {

--- a/lib/features/service_civique/detail/service_civique_detail_middleware.dart
+++ b/lib/features/service_civique/detail/service_civique_detail_middleware.dart
@@ -12,7 +12,7 @@ class ServiceCiviqueDetailMiddleware extends MiddlewareClass<AppState> {
   ServiceCiviqueDetailMiddleware(this._repository);
 
   @override
-  call(Store<AppState> store, action, NextDispatcher next) async {
+  void call(Store<AppState> store, action, NextDispatcher next) async {
     next(action);
     if (action is GetServiceCiviqueDetailAction) {
       store.dispatch(ServiceCiviqueDetailLoadingAction());

--- a/lib/features/service_civique/search/search_service_civique_middleware.dart
+++ b/lib/features/service_civique/search/search_service_civique_middleware.dart
@@ -14,7 +14,7 @@ class SearchServiceCiviqueMiddleware extends MiddlewareClass<AppState> {
   SearchServiceCiviqueMiddleware(this._repository);
 
   @override
-  call(Store<AppState> store, action, NextDispatcher next) async {
+  void call(Store<AppState> store, action, NextDispatcher next) async {
     next(action);
     final loginState = store.state.loginState;
     if (loginState is LoginSuccessState) {

--- a/lib/features/tech/action_logging_middleware.dart
+++ b/lib/features/tech/action_logging_middleware.dart
@@ -4,7 +4,7 @@ import 'package:redux/redux.dart';
 
 class ActionLoggingMiddleware extends MiddlewareClass<AppState> {
   @override
-  call(Store<AppState> store, action, NextDispatcher next) {
+  void call(Store<AppState> store, action, NextDispatcher next) {
     Log.d("ACTIONS - " + _stripActionName(action));
     next(action);
   }

--- a/lib/features/tech/crashlytics_middleware.dart
+++ b/lib/features/tech/crashlytics_middleware.dart
@@ -12,7 +12,7 @@ class CrashlyticsMiddleware extends MiddlewareClass<AppState> {
   CrashlyticsMiddleware(this.crashlytics);
 
   @override
-  call(Store<AppState> store, dynamic action, NextDispatcher next) {
+  void call(Store<AppState> store, dynamic action, NextDispatcher next) {
     _lastActions.add(action.toString());
 
     crashlytics.setCustomKey("last_actions", _formatQueueForCrashlytics());

--- a/lib/features/tracking/tracking_event_middleware.dart
+++ b/lib/features/tracking/tracking_event_middleware.dart
@@ -10,7 +10,7 @@ class TrackingEventMiddleware extends MiddlewareClass<AppState> {
   TrackingEventMiddleware(this._repository);
 
   @override
-  call(Store<AppState> store, action, NextDispatcher next) {
+  void call(Store<AppState> store, action, NextDispatcher next) {
     next(action);
     if (action is TrackingEventAction) {
       final loginState = store.state.loginState;

--- a/lib/features/tracking/user_tracking_structure_middleware.dart
+++ b/lib/features/tracking/user_tracking_structure_middleware.dart
@@ -8,7 +8,7 @@ import '../../redux/app_state.dart';
 
 class UserTrackingStructureMiddleware extends MiddlewareClass<AppState> {
   @override
-  call(Store<AppState> store, action, NextDispatcher next) {
+  void call(Store<AppState> store, action, NextDispatcher next) {
     next(action);
     if (action is LoginSuccessAction) {
       final structureName = _getStructureName(action.user.loginMode);

--- a/lib/features/user_action/create/user_action_create_middleware.dart
+++ b/lib/features/user_action/create/user_action_create_middleware.dart
@@ -11,7 +11,7 @@ class UserActionCreateMiddleware extends MiddlewareClass<AppState> {
   UserActionCreateMiddleware(this._repository);
 
   @override
-  call(Store<AppState> store, action, NextDispatcher next) async {
+  void call(Store<AppState> store, action, NextDispatcher next) async {
     next(action);
     final loginState = store.state.loginState;
     if (loginState is LoginSuccessState && action is UserActionCreateRequestAction) {

--- a/lib/features/user_action/delete/user_action_delete_middleware.dart
+++ b/lib/features/user_action/delete/user_action_delete_middleware.dart
@@ -9,7 +9,7 @@ class UserActionDeleteMiddleware extends MiddlewareClass<AppState> {
   UserActionDeleteMiddleware(this._repository);
 
   @override
-  call(Store<AppState> store, action, NextDispatcher next) async {
+  void call(Store<AppState> store, action, NextDispatcher next) async {
     next(action);
     if (action is UserActionDeleteRequestAction) {
       store.dispatch(UserActionDeleteLoadingAction());

--- a/lib/features/user_action/list/user_action_list_middleware.dart
+++ b/lib/features/user_action/list/user_action_list_middleware.dart
@@ -10,7 +10,7 @@ class UserActionListMiddleware extends MiddlewareClass<AppState> {
   UserActionListMiddleware(this._repository);
 
   @override
-  call(Store<AppState> store, action, NextDispatcher next) async {
+  void call(Store<AppState> store, action, NextDispatcher next) async {
     next(action);
     final loginState = store.state.loginState;
     if (loginState is LoginSuccessState && action is UserActionListRequestAction) {

--- a/lib/features/user_action/update/user_action_update_middleware.dart
+++ b/lib/features/user_action/update/user_action_update_middleware.dart
@@ -9,7 +9,7 @@ class UserActionUpdateMiddleware extends MiddlewareClass<AppState> {
   UserActionUpdateMiddleware(this._repository);
 
   @override
-  call(Store<AppState> store, action, NextDispatcher next) async {
+  void call(Store<AppState> store, action, NextDispatcher next) async {
     next(action);
     if (action is UserActionUpdateRequestAction) {
       _repository.updateActionStatus(action.userId, action.actionId, action.newStatus);

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -59,7 +59,7 @@ import 'configuration/configuration.dart';
 import 'crashlytics/crashlytics.dart';
 import 'network/logging_interceptor.dart';
 
-main() async {
+void main() async {
   WidgetsFlutterBinding.ensureInitialized();
   await Firebase.initializeApp();
 
@@ -122,13 +122,13 @@ Future<Store<AppState>> _initializeReduxStore(
   final poleEmploiTokenRepository = PoleEmploiTokenRepository();
   final accessTokenRetriever = AuthAccessTokenRetriever(authenticator);
   final crashlytics = CrashlyticsWithFirebase(FirebaseCrashlytics.instance);
-  var defaultContext = SecurityContext.defaultContext;
+  final defaultContext = SecurityContext.defaultContext;
   try {
     defaultContext.setTrustedCertificatesBytes(utf8.encode(configuration.iSRGX1CertificateForOldDevices));
   } catch (e, stack) {
     crashlytics.recordNonNetworkException(e, stack);
   }
-  Client clientWithCertificate = IOClient(HttpClient(context: defaultContext));
+  final Client clientWithCertificate = IOClient(HttpClient(context: defaultContext));
   final httpClient = InterceptedClient.build(
     client: clientWithCertificate,
     interceptors: [

--- a/lib/models/saved_search/saved_search_extractors.dart
+++ b/lib/models/saved_search/saved_search_extractors.dart
@@ -23,7 +23,7 @@ class OffreEmploiSearchExtractor extends AbstractSearchExtractor<OffreEmploiSave
     final state = store.state.offreEmploiSearchParametersState as OffreEmploiSearchParametersInitializedState;
     final metier = state.keywords;
     final location = state.location;
-    String _title = _setTitleForOffer(metier, location?.libelle);
+    final String _title = _setTitleForOffer(metier, location?.libelle);
     return OffreEmploiSavedSearch(
       id: "",
       title: _title,

--- a/lib/models/service_civique.dart
+++ b/lib/models/service_civique.dart
@@ -18,7 +18,7 @@ class ServiceCivique extends Equatable {
   });
 
   factory ServiceCivique.fromJson(dynamic json) {
-    String? stringDate = (json["dateDeDebut"] as String?);
+    final String? stringDate = (json["dateDeDebut"] as String?);
     return ServiceCivique(
       id: json["id"] as String,
       title: json["titre"] as String,

--- a/lib/models/service_civique/service_civique_detail.dart
+++ b/lib/models/service_civique/service_civique_detail.dart
@@ -36,8 +36,8 @@ class ServiceCiviqueDetail extends Equatable {
   });
 
   factory ServiceCiviqueDetail.fromJson(dynamic json) {
-    String? stringDateDebut = (json["dateDeDebut"] as String?);
-    String? stringDateFin = (json["dateDeFin"] as String?);
+    final String? stringDateDebut = (json["dateDeDebut"] as String?);
+    final String? stringDateFin = (json["dateDeFin"] as String?);
     return ServiceCiviqueDetail(
       titre: json["titre"] as String,
       dateDeDebut: stringDateDebut!.toDateTimeUtcOnLocalTimeZone().toDayWithFullMonth(),

--- a/lib/models/user_action.dart
+++ b/lib/models/user_action.dart
@@ -47,7 +47,7 @@ UserActionCreator _creator(dynamic json) {
   if (creatorType == "jeune") {
     return JeuneActionCreator();
   } else {
-    var creatorName = json["creator"] as String;
+    final creatorName = json["creator"] as String;
     return ConseillerActionCreator(
       name: creatorName,
     );

--- a/lib/network/post_saved_search/post_offre_emploi_saved_search.dart
+++ b/lib/network/post_saved_search/post_offre_emploi_saved_search.dart
@@ -49,7 +49,7 @@ String? getLocationType(Location? location, LocationType type) =>
     (location != null && location.type == type) ? location.code : null;
 
 List<String> getExperience(List<ExperienceFiltre>? experience) {
-  List<String> list = [];
+  final List<String> list = [];
   if (experience != null && experience.isNotEmpty) {
     for (var element in experience) {
       list.add(FiltresRequest.experienceToUrlParameter(element));
@@ -59,7 +59,7 @@ List<String> getExperience(List<ExperienceFiltre>? experience) {
 }
 
 List<String> getContrat(List<ContratFiltre>? contrat) {
-  List<String> list = [];
+  final List<String> list = [];
   if (contrat != null && contrat.isNotEmpty) {
     for (var element in contrat) {
       list.add(FiltresRequest.contratToUrlParameter(element));
@@ -69,7 +69,7 @@ List<String> getContrat(List<ContratFiltre>? contrat) {
 }
 
 List<String> getDuration(List<DureeFiltre>? duration) {
-  List<String> list = [];
+  final List<String> list = [];
   if (duration != null && duration.isNotEmpty) {
     for (var element in duration) {
       list.add(FiltresRequest.dureeToUrlParameter(element));

--- a/lib/network/post_tracking_event_request.dart
+++ b/lib/network/post_tracking_event_request.dart
@@ -54,7 +54,7 @@ class PostTrackingEvent extends JsonSerializable {
         "emetteur": PostTrackingEmetteur(userId: userId, loginMode: loginMode).toJson(),
       };
 
-  _toString(EventType event) {
+  String _toString(EventType event) {
     switch (event) {
       case EventType.MESSAGE_ENVOYE:
         return "MESSAGE_ENVOYE";

--- a/lib/network/post_user_action_request.dart
+++ b/lib/network/post_user_action_request.dart
@@ -16,7 +16,7 @@ class PostUserActionRequest implements JsonSerializable {
     "status": _toString(status)
   };
 
-  _toString(UserActionStatus status) {
+  String _toString(UserActionStatus status) {
     switch (status) {
       case UserActionStatus.NOT_STARTED:
         return "not_started";

--- a/lib/network/put_user_action_request.dart
+++ b/lib/network/put_user_action_request.dart
@@ -10,7 +10,7 @@ class PutUserActionRequest implements JsonSerializable {
   @override
   Map<String, dynamic> toJson() => {"status": _toString(status)};
 
-  _toString(UserActionStatus status) {
+  String _toString(UserActionStatus status) {
     switch (status) {
       case UserActionStatus.NOT_STARTED:
         return "not_started";

--- a/lib/pages/chat_page.dart
+++ b/lib/pages/chat_page.dart
@@ -127,6 +127,7 @@ class _ChatPageState extends State<ChatPage> with WidgetsBindingObserver {
             child: Row(
               children: [
                 Flexible(
+                  flex: 1,
                   child: TextField(
                     controller: _controller,
                     keyboardType: TextInputType.multiline,
@@ -148,9 +149,7 @@ class _ChatPageState extends State<ChatPage> with WidgetsBindingObserver {
                         borderSide: BorderSide(color: AppColors.primaryLighten, width: 1),
                       ),
                     ),
-                    style: TextStyles.textSRegular(),
                   ),
-                  flex: 1,
                 ),
                 SizedBox(width: Margins.spacing_s),
                 FloatingActionButton(

--- a/lib/pages/choix_organisme_explaination_page.dart
+++ b/lib/pages/choix_organisme_explaination_page.dart
@@ -46,7 +46,7 @@ class ChoixOrganismeExplainationPage extends TraceableStatelessWidget {
                           Padding(
                             padding:
                                 const EdgeInsets.fromLTRB(Margins.spacing_m, Margins.spacing_m, Margins.spacing_m, 0),
-                            child: Container(
+                            child: DecoratedBox(
                               decoration: BoxDecoration(color: Colors.white, borderRadius: BorderRadius.circular(8)),
                               child: Padding(
                                 padding: const EdgeInsets.all(Margins.spacing_m),

--- a/lib/pages/choix_organisme_page.dart
+++ b/lib/pages/choix_organisme_page.dart
@@ -42,7 +42,7 @@ class ChoixOrganismePage extends TraceableStatelessWidget {
                         Padding(
                           padding:
                               const EdgeInsets.fromLTRB(Margins.spacing_m, Margins.spacing_m, Margins.spacing_m, 0),
-                          child: Container(
+                          child: DecoratedBox(
                             decoration: BoxDecoration(color: Colors.white, borderRadius: BorderRadius.circular(8)),
                             child: Padding(
                               padding: const EdgeInsets.all(Margins.spacing_m),

--- a/lib/pages/entree_page.dart
+++ b/lib/pages/entree_page.dart
@@ -57,7 +57,7 @@ class EntreePage extends TraceableStatelessWidget {
               alignment: Alignment.bottomCenter,
               child: Padding(
                 padding: const EdgeInsets.all(Margins.spacing_m),
-                child: Container(
+                child: DecoratedBox(
                   decoration: BoxDecoration(
                     color: Colors.white,
                     borderRadius: BorderRadius.circular(16),

--- a/lib/pages/immersion_details_page.dart
+++ b/lib/pages/immersion_details_page.dart
@@ -119,11 +119,14 @@ class ImmersionDetailsPage extends TraceableStatelessWidget {
         ),
         if (viewModel.displayState == ImmersionDetailsPageDisplayState.SHOW_INCOMPLETE_DETAILS)
           Align(
-            child: _incompleteDataFooter(viewModel),
             alignment: Alignment.bottomCenter,
+            child: _incompleteDataFooter(viewModel),
           )
         else
-          Align(child: _footer(context, viewModel), alignment: Alignment.bottomCenter)
+          Align(
+            alignment: Alignment.bottomCenter,
+            child: _footer(context, viewModel),
+          )
       ],
     );
   }

--- a/lib/pages/immersion_search_page.dart
+++ b/lib/pages/immersion_search_page.dart
@@ -122,7 +122,7 @@ class _ImmersionSearchPageState extends State<ImmersionSearchPage> {
     );
   }
 
-  _setSelectedMetier(Metier? selectedMetier) {
+  void _setSelectedMetier(Metier? selectedMetier) {
     if (selectedMetier != null) {
       _selectedMetierCodeRome = selectedMetier.codeRome;
       _selectedMetierTitle = selectedMetier.libelle;

--- a/lib/pages/offre_emploi_details_page.dart
+++ b/lib/pages/offre_emploi_details_page.dart
@@ -142,13 +142,13 @@ class OffreEmploiDetailsPage extends TraceableStatelessWidget {
         ),
         if (url != null && id != null)
           Align(
-            child: _footer(context, url, id, viewModel.title),
             alignment: Alignment.bottomCenter,
+            child: _footer(context, url, id, viewModel.title),
           )
         else if (viewModel.displayState == OffreEmploiDetailsPageDisplayState.SHOW_INCOMPLETE_DETAILS && id != null)
           Align(
-            child: _incompleteDataFooter(context, id),
             alignment: Alignment.bottomCenter,
+            child: _incompleteDataFooter(context, id),
           )
       ],
     );
@@ -196,11 +196,11 @@ class OffreEmploiDetailsPage extends TraceableStatelessWidget {
 
   Widget _profileDescription(OffreEmploiDetailsPageViewModel viewModel) {
     final experience = viewModel.experience;
-    Widget? skills = _skillsBlock(skills: viewModel.skills);
-    Widget? softSkills = _softSkillsBlock(softSkills: viewModel.softSkills);
-    Widget? educations = _educationsBlock(educations: viewModel.educations);
-    Widget? languages = _languagesBlock(languages: viewModel.languages);
-    Widget? driverLicences = _driverLicencesBlock(driverLicences: viewModel.driverLicences);
+    final Widget? skills = _skillsBlock(skills: viewModel.skills);
+    final Widget? softSkills = _softSkillsBlock(softSkills: viewModel.softSkills);
+    final Widget? educations = _educationsBlock(educations: viewModel.educations);
+    final Widget? languages = _languagesBlock(languages: viewModel.languages);
+    final Widget? driverLicences = _driverLicencesBlock(driverLicences: viewModel.driverLicences);
     return Column(
       crossAxisAlignment: CrossAxisAlignment.start,
       children: [

--- a/lib/pages/router_page.dart
+++ b/lib/pages/router_page.dart
@@ -69,7 +69,7 @@ class _RouterPageState extends State<RouterPage> {
   }
 
   Future<void> _handleStoppedApplicationOpenedFromPushNotification() async {
-    RemoteMessage? initialMessage = await FirebaseMessaging.instance.getInitialMessage();
+    final RemoteMessage? initialMessage = await FirebaseMessaging.instance.getInitialMessage();
     if (initialMessage != null) _handleDeepLink(initialMessage);
   }
 

--- a/lib/pages/saved_search_tab_page.dart
+++ b/lib/pages/saved_search_tab_page.dart
@@ -161,7 +161,7 @@ class _SavedSearchTabPageState extends State<SavedSearchTabPage> {
       scrollDirection: Axis.vertical,
       itemCount: offreEmplois.length,
       itemBuilder: (context, position) {
-        double topPadding = (position == 0) ? Margins.spacing_m : 0;
+        final double topPadding = (position == 0) ? Margins.spacing_m : 0;
         return Padding(
           padding: EdgeInsets.fromLTRB(Margins.spacing_base, topPadding, Margins.spacing_base, Margins.spacing_base),
           child: _buildCard(context, offreEmplois[position], viewModel),
@@ -192,7 +192,7 @@ class _SavedSearchTabPageState extends State<SavedSearchTabPage> {
       scrollDirection: Axis.vertical,
       itemCount: savedSearchsImmersion.length,
       itemBuilder: (context, position) {
-        double topPadding = (position == 0) ? Margins.spacing_m : 0;
+        final double topPadding = (position == 0) ? Margins.spacing_m : 0;
         return Padding(
           padding: EdgeInsets.fromLTRB(Margins.spacing_base, topPadding, Margins.spacing_base, Margins.spacing_base),
           child: _buildImmersionCard(context, savedSearchsImmersion[position], viewModel),

--- a/lib/pages/service_civique/service_civique_detail_page.dart
+++ b/lib/pages/service_civique/service_civique_detail_page.dart
@@ -78,9 +78,9 @@ class ServiceCiviqueDetailPage extends TraceableStatelessWidget {
   Widget _content(BuildContext context, ServiceCiviqueDetailViewModel viewModel) {
     final ServiceCiviqueDetail? detail = viewModel.detail;
     final ServiceCivique? serviceCivique = viewModel.serviceCivique;
-    String organisation = detail?.organisation ?? serviceCivique?.companyName ?? "";
-    String titre = detail?.titre ?? serviceCivique?.title ?? "";
-    String domaine = Domaine.fromTag(detail?.domaine)?.titre ?? Domaine.fromTag(serviceCivique?.domain)?.titre ?? "";
+    final String organisation = detail?.organisation ?? serviceCivique?.companyName ?? "";
+    final String titre = detail?.titre ?? serviceCivique?.title ?? "";
+    final String domaine = Domaine.fromTag(detail?.domaine)?.titre ?? Domaine.fromTag(serviceCivique?.domain)?.titre ?? "";
     return Stack(
       children: [
         SingleChildScrollView(
@@ -110,8 +110,8 @@ class ServiceCiviqueDetailPage extends TraceableStatelessWidget {
                 if (detail != null) _spacer(60),
                 if (viewModel.displayState == DisplayState.EMPTY)
                   Align(
-                    child: _incompleteDataFooter(),
                     alignment: Alignment.bottomCenter,
+                    child: _incompleteDataFooter(),
                   )
               ],
             ),
@@ -119,8 +119,8 @@ class ServiceCiviqueDetailPage extends TraceableStatelessWidget {
         ),
         if (detail?.lienAnnonce != null)
           Align(
-            child: _footer(context, detail!.lienAnnonce!, detail.titre),
             alignment: Alignment.bottomCenter,
+            child: _footer(context, detail!.lienAnnonce!, detail.titre),
           )
       ],
     );
@@ -153,7 +153,7 @@ class ServiceCiviqueDetailPage extends TraceableStatelessWidget {
   }
 
   Widget _description(ServiceCiviqueDetail detail) {
-    String missionFullAdresse = detail.adresseMission != null && detail.codePostal != null
+    final String missionFullAdresse = detail.adresseMission != null && detail.codePostal != null
         ? detail.adresseMission! + ", " + detail.codePostal! + " " + detail.ville
         : detail.ville;
     return Column(

--- a/lib/presentation/favori_list_view_model.dart
+++ b/lib/presentation/favori_list_view_model.dart
@@ -28,7 +28,7 @@ class FavorisListViewModel<FAVORIS_MODEL, FAVORIS_VIEW_MODEL> extends Equatable 
     RelevantFavorisExtractor<FAVORIS_MODEL> relevantFavorisExtractor,
     FavorisViewModelTransformer<FAVORIS_MODEL, FAVORIS_VIEW_MODEL> viewModelTransformer,
   ) {
-    retry() => store.dispatch(FavoriListRequestAction<FAVORIS_MODEL>());
+    void retry() => store.dispatch(FavoriListRequestAction<FAVORIS_MODEL>());
     if (relevantFavorisExtractor.isDataInitialized(store)) {
       final favoris = relevantFavorisExtractor.getRelevantFavoris(store);
       return FavorisListViewModel._(

--- a/lib/presentation/service_civique_view_model.dart
+++ b/lib/presentation/service_civique_view_model.dart
@@ -38,7 +38,7 @@ class ServiceCiviqueViewModel extends Equatable {
   });
 
   factory ServiceCiviqueViewModel.create(Store<AppState> store) {
-    var searchResultState = store.state.serviceCiviqueSearchResultState;
+    final searchResultState = store.state.serviceCiviqueSearchResultState;
     return ServiceCiviqueViewModel._(
         locations: store.state.searchLocationState.locations
             .map((location) => LocationViewModel.fromLocation(location))
@@ -79,9 +79,9 @@ class ServiceCiviqueViewModel extends Equatable {
 int? _filtersCount(ServiceCiviqueSearchResultState state) {
   if (state is ServiceCiviqueSearchResultDataState) {
     final SearchServiceCiviqueRequest lastRequest = state.lastRequest;
-    int distanceCount = lastRequest.distance != null && lastRequest.distance != defaultDistanceValue ? 1 : 0;
-    int startDateCount = lastRequest.startDate != null ? 1 : 0;
-    int domainCount = lastRequest.domain != null && lastRequest.domain != Domaine.all.tag ? 1 : 0;
+    final int distanceCount = lastRequest.distance != null && lastRequest.distance != defaultDistanceValue ? 1 : 0;
+    final int startDateCount = lastRequest.startDate != null ? 1 : 0;
+    final int domainCount = lastRequest.domain != null && lastRequest.domain != Domaine.all.tag ? 1 : 0;
     return distanceCount + startDateCount + domainCount;
   } else {
     return null;

--- a/lib/push/firebase_push_notification_manager.dart
+++ b/lib/push/firebase_push_notification_manager.dart
@@ -24,13 +24,13 @@ class FirebasePushNotificationManager extends PushNotificationManager {
 
   @override
   Future<String?> getToken() async {
-    String? token = await _firebaseMessaging.getToken();
+    final String? token = await _firebaseMessaging.getToken();
     Log.d("FirebaseMessaging token: $token");
     return token;
   }
 
   Future<void> _requestPermission() async {
-    NotificationSettings settings = await _firebaseMessaging.requestPermission(
+    final NotificationSettings settings = await _firebaseMessaging.requestPermission(
       alert: true,
       badge: true,
       sound: true,

--- a/lib/repositories/metier_repository.dart
+++ b/lib/repositories/metier_repository.dart
@@ -13,8 +13,8 @@ class MetierRepository {
   }
 
   String _removeDiacritics(String str) {
-    var withDia = 'ÀÁÂÃÄàáâäÒÓÔÕÕÖòóôõöÈÉÊËèéêëÇçÌÍÎÏìíîïÙÚÛÜùúûü';
-    var withoutDia = 'AAAAAaaaaOOOOOOoooooEEEEeeeeCcIIIIiiiiUUUUuuuu';
+    const withDia = 'ÀÁÂÃÄàáâäÒÓÔÕÕÖòóôõöÈÉÊËèéêëÇçÌÍÎÏìíîïÙÚÛÜùúûü';
+    const withoutDia = 'AAAAAaaaaOOOOOOoooooEEEEeeeeCcIIIIiiiiUUUUuuuu';
 
     for (int i = 0; i < withDia.length; i++) {
       str = str.replaceAll(withDia[i], withoutDia[i]);

--- a/lib/widgets/bottom_sheets/immersion_saved_search_bottom_sheet.dart
+++ b/lib/widgets/bottom_sheets/immersion_saved_search_bottom_sheet.dart
@@ -29,7 +29,7 @@ class ImmersionSavedSearchBottomSheet extends AbstractSavedSearchBottomSheet<Imm
   }
 
   @override
-  dismissBottomSheetIfNeeded(BuildContext context, ImmersionSavedSearchViewModel newVm) {
+  void dismissBottomSheetIfNeeded(BuildContext context, ImmersionSavedSearchViewModel newVm) {
     if (newVm.displayState == CreateSavedSearchDisplayState.TO_DISMISS) {
       Navigator.pop(context);
       showSuccessfulSnackBar(context, Strings.savedSearchSuccessfullyCreated);

--- a/lib/widgets/bottom_sheets/offre_emploi_bottom_sheet_form.dart
+++ b/lib/widgets/bottom_sheets/offre_emploi_bottom_sheet_form.dart
@@ -147,9 +147,9 @@ class _OffreEmploiBottomSheetFormState extends State<OffreEmploiBottomSheetForm>
   }
 
   Widget _savedSearchFilters(OffreEmploiSavedSearch searchViewModel) {
-    List<TagInfo> _tags = [TagInfo(searchViewModel.getSavedSearchTagLabel(), false)];
-    String? _keyWords = searchViewModel.keywords;
-    String? _location = searchViewModel.location?.libelle;
+    final List<TagInfo> _tags = [TagInfo(searchViewModel.getSavedSearchTagLabel(), false)];
+    final String? _keyWords = searchViewModel.keywords;
+    final String? _location = searchViewModel.location?.libelle;
     if (_keyWords != null && _keyWords.isNotEmpty) _tags.add(TagInfo(_keyWords, false));
     if (_location != null && _location.isNotEmpty) _tags.add(TagInfo(_location, true));
     return Padding(

--- a/lib/widgets/bottom_sheets/offre_emploi_saved_search_bottom_sheet.dart
+++ b/lib/widgets/bottom_sheets/offre_emploi_saved_search_bottom_sheet.dart
@@ -38,7 +38,7 @@ class OffreEmploiSavedSearchBottomSheet extends AbstractSavedSearchBottomSheet<O
   }
 
   @override
-  dismissBottomSheetIfNeeded(BuildContext context, OffreEmploiSavedSearchViewModel newVm) {
+  void dismissBottomSheetIfNeeded(BuildContext context, OffreEmploiSavedSearchViewModel newVm) {
     if (newVm.displayState == CreateSavedSearchDisplayState.TO_DISMISS) {
       Navigator.pop(context);
       showSuccessfulSnackBar(context, Strings.savedSearchSuccessfullyCreated);

--- a/lib/widgets/bottom_sheets/saved_search_bottom_sheet.dart
+++ b/lib/widgets/bottom_sheets/saved_search_bottom_sheet.dart
@@ -29,5 +29,5 @@ abstract class AbstractSavedSearchBottomSheet<SAVED_SEARCH_MODEL> extends Tracea
 
   Widget buildSaveSearch(BuildContext context, SavedSearchViewModel<SAVED_SEARCH_MODEL> itemViewModel);
 
-  dismissBottomSheetIfNeeded(BuildContext context, SavedSearchViewModel<SAVED_SEARCH_MODEL> newVm);
+  void dismissBottomSheetIfNeeded(BuildContext context, SavedSearchViewModel<SAVED_SEARCH_MODEL> newVm);
 }

--- a/lib/widgets/bottom_sheets/user_action_create_bottom_sheet.dart
+++ b/lib/widgets/bottom_sheets/user_action_create_bottom_sheet.dart
@@ -33,7 +33,7 @@ class _CreateUserActionBottomSheetState extends State<CreateUserActionBottomShee
     _initialStatus = UserActionStatus.NOT_STARTED;
   }
 
-  _update(UserActionStatus newStatus) {
+  void _update(UserActionStatus newStatus) {
     setState(() {
       _initialStatus = newStatus;
     });

--- a/lib/widgets/bottom_sheets/user_action_details_bottom_sheet.dart
+++ b/lib/widgets/bottom_sheets/user_action_details_bottom_sheet.dart
@@ -119,7 +119,7 @@ class _UserActionDetailsBottomSheetState extends State<UserActionDetailsBottomSh
     );
   }
 
-  _update(UserActionStatus newStatus) {
+  void _update(UserActionStatus newStatus) {
     setState(() {
       actionStatus = newStatus;
     });
@@ -263,7 +263,7 @@ class _UserActionDetailsBottomSheetState extends State<UserActionDetailsBottomSh
     }
   }
 
-  _trackSuccessfulUpdate() {
+  void _trackSuccessfulUpdate() {
     MatomoTracker.trackScreenWithName(AnalyticsScreenNames.updateUserAction, AnalyticsScreenNames.userActionDetails);
   }
 }

--- a/lib/widgets/buttons/carousel_button.dart
+++ b/lib/widgets/buttons/carousel_button.dart
@@ -24,6 +24,7 @@ class CarouselButton extends StatelessWidget {
         shape: MaterialStateProperty.all(StadiumBorder()),
         side: MaterialStateProperty.all(BorderSide(color: isActive ? AppColors.primary : AppColors.grey800, width: 1)),
       ),
+      onPressed: onPressed,
       child: Padding(
         padding: const EdgeInsets.symmetric(horizontal: 4, vertical: 16),
         child: Row(
@@ -36,7 +37,6 @@ class CarouselButton extends StatelessWidget {
           ],
         ),
       ),
-      onPressed: onPressed,
     );
   }
 }

--- a/lib/widgets/cards/data_card.dart
+++ b/lib/widgets/cards/data_card.dart
@@ -32,8 +32,8 @@ class DataCard<T> extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    List<String> nonEmptyDataTags = dataTag.where((element) => element.isNotEmpty).toList();
-    return Container(
+    final List<String> nonEmptyDataTags = dataTag.where((element) => element.isNotEmpty).toList();
+    return DecoratedBox(
       decoration: BoxDecoration(color: Colors.white, borderRadius: BorderRadius.all(Radius.circular(16)), boxShadow: [
         Shadows.boxShadow,
       ]),

--- a/lib/widgets/cards/profil_card.dart
+++ b/lib/widgets/cards/profil_card.dart
@@ -15,7 +15,7 @@ class ProfilCard extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    return Container(
+    return DecoratedBox(
       decoration: BoxDecoration(color: Colors.white, borderRadius: BorderRadius.all(Radius.circular(16)), boxShadow: [
         Shadows.boxShadow,
       ]),

--- a/lib/widgets/cards/rendezvous_card.dart
+++ b/lib/widgets/cards/rendezvous_card.dart
@@ -33,7 +33,7 @@ class _Container extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    return Container(
+    return DecoratedBox(
       decoration: BoxDecoration(
         color: Colors.white,
         borderRadius: BorderRadius.circular(Margins.spacing_base),

--- a/lib/widgets/cards/saved_search_card.dart
+++ b/lib/widgets/cards/saved_search_card.dart
@@ -26,8 +26,8 @@ class SavedSearchCard extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    List<String> nonEmptyDataTags = dataTag.where((element) => element.trim().isNotEmpty).toList();
-    return Container(
+    final List<String> nonEmptyDataTags = dataTag.where((element) => element.trim().isNotEmpty).toList();
+    return DecoratedBox(
       decoration: BoxDecoration(color: Colors.white, borderRadius: BorderRadius.all(Radius.circular(16)), boxShadow: [
         Shadows.boxShadow,
       ]),
@@ -85,16 +85,16 @@ class SavedSearchCard extends StatelessWidget {
     return InkWell(
       splashColor: AppColors.primaryLighten,
       customBorder: CircleBorder(),
+      onTap: onDeleteTap ?? () {},
       child: Padding(
         padding: const EdgeInsets.all(16),
         child: SvgPicture.asset(Drawables.icTrash),
       ),
-      onTap: onDeleteTap ?? () {},
     );
   }
 
   Widget _buildDataTags(List<String> nonEmptyDataTags, String? lieu) {
-    var list = nonEmptyDataTags.map((tag) => DataTag(label: tag)).toList();
+    final list = nonEmptyDataTags.map((tag) => DataTag(label: tag)).toList();
     if (lieu != null) {
       list.add(DataTag(
         label: lieu,

--- a/lib/widgets/cards/user_action_card.dart
+++ b/lib/widgets/cards/user_action_card.dart
@@ -14,7 +14,7 @@ class UserActionCard extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    return Container(
+    return DecoratedBox(
       decoration: BoxDecoration(color: Colors.white, borderRadius: BorderRadius.circular(16), boxShadow: [
         Shadows.boxShadow,
       ]),

--- a/lib/widgets/cej_information_content_card.dart
+++ b/lib/widgets/cej_information_content_card.dart
@@ -19,7 +19,7 @@ class CejInformationContentCard extends StatelessWidget {
   Widget build(BuildContext context) {
     return Padding(
       padding: const EdgeInsets.all(Margins.spacing_m),
-      child: Container(
+      child: DecoratedBox(
         decoration: BoxDecoration(color: Colors.white, borderRadius: BorderRadius.circular(8)),
         child: SingleChildScrollView(
           child: Padding(

--- a/lib/widgets/checkbox_group.dart
+++ b/lib/widgets/checkbox_group.dart
@@ -40,7 +40,7 @@ class _CheckBoxGroupState<T extends CheckboxValueViewModel> extends State<CheckB
       children: [
         Text(widget.title, style: TextStyles.textBaseBold),
         SizedBox(height: Margins.spacing_base),
-        Container(
+        DecoratedBox(
           decoration:
               BoxDecoration(color: Colors.white, borderRadius: BorderRadius.all(Radius.circular(16)), boxShadow: [
             Shadows.boxShadow,
@@ -70,7 +70,7 @@ class _CheckBoxGroupState<T extends CheckboxValueViewModel> extends State<CheckB
         setState(() {
           if (value != null) {
             _optionsSelectionStatus[viewModel] = value;
-            var listOfSelectedOptions = _listOfSelectedOptions();
+            final listOfSelectedOptions = _listOfSelectedOptions();
             widget.onSelectedOptionsUpdated(listOfSelectedOptions);
           }
         });

--- a/lib/widgets/default_animated_switcher.dart
+++ b/lib/widgets/default_animated_switcher.dart
@@ -4,7 +4,7 @@ class DefaultAnimatedSwitcher extends AnimatedSwitcher {
   DefaultAnimatedSwitcher({required Widget child})
       : super(
           duration: const Duration(milliseconds: 400),
-          transitionBuilder: (child, animation) => FadeTransition(child: child, opacity: animation),
+          transitionBuilder: (child, animation) => FadeTransition(opacity: animation, child: child),
           switchInCurve: Curves.easeInOutBack,
           switchOutCurve: Curves.easeInOutBack,
           child: child,

--- a/lib/widgets/default_menu_item.dart
+++ b/lib/widgets/default_menu_item.dart
@@ -37,10 +37,10 @@ class DefaultMenuItem extends StatelessWidget {
               clipBehavior: Clip.none,
               children: [
                 SizedBox(
-                  child: SvgPicture.asset(drawableRes, color: color),
                   height: Dimens.bottomNavigationBarItemHeight,
+                  child: SvgPicture.asset(drawableRes, color: color),
                 ),
-                if (withBadge) Positioned(child: SvgPicture.asset(Drawables.icBadge), top: -1, left: 12),
+                if (withBadge) Positioned(top: -1, left: 12, child: SvgPicture.asset(Drawables.icBadge)),
               ],
             ),
             SizedBox(height: Margins.spacing_s),

--- a/lib/widgets/entree_biseau_background.dart
+++ b/lib/widgets/entree_biseau_background.dart
@@ -10,8 +10,8 @@ class EntreeBiseauBackground extends StatelessWidget {
       children: [
         Container(color: AppColors.primary),
         ClipPath(
-          child: Container(color: AppColors.primaryDarken.withOpacity(0.25)),
           clipper: DiagonalClipper(),
+          child: Container(color: AppColors.primaryDarken.withOpacity(0.25)),
         ),
       ],
     );

--- a/lib/widgets/location_autocomplete.dart
+++ b/lib/widgets/location_autocomplete.dart
@@ -56,17 +56,17 @@ class LocationAutocomplete extends StatelessWidget {
                 shape: const RoundedRectangleBorder(
                   borderRadius: BorderRadius.vertical(bottom: Radius.circular(4.0)),
                 ),
+                color: Colors.white,
                 child: Container(
                   width: constraints.biggest.width,
+                  color: Colors.white,
                   child: ListView.builder(
                     padding: EdgeInsets.zero,
                     shrinkWrap: true,
                     itemCount: locationViewModels.length + _fakeItemsAddedToLeverageAdditionalScrollInAutocomplete,
                     itemBuilder: (BuildContext context, int index) => _listTile(index, onSelected),
                   ),
-                  color: Colors.white,
                 ),
-                color: Colors.white,
               ));
         },
         fieldViewBuilder: (
@@ -131,7 +131,7 @@ class LocationAutocomplete extends StatelessWidget {
   }
 
   void _putBackLastLocationSetOnFocusLost(bool hasFocus, TextEditingController textEditingController) {
-    var title = getPreviouslySelectedTitle();
+    final title = getPreviouslySelectedTitle();
     if (!hasFocus && title != null) {
       textEditingController.text = title;
     }

--- a/lib/widgets/metier_autocomplete.dart
+++ b/lib/widgets/metier_autocomplete.dart
@@ -83,8 +83,10 @@ class MetierAutocomplete extends StatelessWidget {
           shape: const RoundedRectangleBorder(
             borderRadius: BorderRadius.vertical(bottom: Radius.circular(4.0)),
           ),
+          color: Colors.white,
           child: Container(
             width: constraints.biggest.width,
+            color: Colors.white,
             child: ListView.builder(
               padding: EdgeInsets.zero,
               shrinkWrap: true,
@@ -97,14 +99,12 @@ class MetierAutocomplete extends StatelessWidget {
                 );
               },
             ),
-            color: Colors.white,
           ),
-          color: Colors.white,
         ));
   }
 
   void _putBackLastLocationSetOnFocusLost(bool hasFocus, TextEditingController textEditingController) {
-    var title = getPreviouslySelectedTitle();
+    final title = getPreviouslySelectedTitle();
     if (!hasFocus && title != null) {
       textEditingController.text = title;
     }

--- a/lib/widgets/onboarding_background.dart
+++ b/lib/widgets/onboarding_background.dart
@@ -13,7 +13,7 @@ class OnboardingBackground extends StatelessWidget {
         Container(color: Color(0xFFE5E5E5)),
         SizedBox(
           height: totalHeight / 2 + Dimens.appBarHeight,
-          child: Container(
+          child: DecoratedBox(
             decoration: BoxDecoration(
               borderRadius: BorderRadius.only(bottomLeft: Radius.circular(200), bottomRight: Radius.circular(200)),
               color: AppColors.primary,

--- a/lib/widgets/tags/tags.dart
+++ b/lib/widgets/tags/tags.dart
@@ -11,7 +11,7 @@ class DataTag extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    return Container(
+    return DecoratedBox(
       decoration: BoxDecoration(
         color: AppColors.primaryLighten,
         borderRadius: BorderRadius.all(Radius.circular(40)),

--- a/lib/widgets/unavailable_content.dart
+++ b/lib/widgets/unavailable_content.dart
@@ -22,7 +22,7 @@ class UnavailableContent extends StatelessWidget {
         crossAxisAlignment: CrossAxisAlignment.start,
         children: [
           SizedBox(height: screenHeight * 0.02),
-          Flexible(child: SvgPicture.asset(Drawables.icNoContent), flex: 1),
+          Flexible(flex: 1, child: SvgPicture.asset(Drawables.icNoContent)),
           SizedBox(height: screenHeight * 0.05),
           Text(_setTitle(), style: TextStyles.textBaseBold, textAlign: TextAlign.center),
           SizedBox(height: screenHeight * 0.03),

--- a/test/doubles/spies.dart
+++ b/test/doubles/spies.dart
@@ -26,7 +26,7 @@ class StoreSpy extends Store<AppState> {
   StoreSpy() : super(reducer, initialState: AppState.initialState(configuration: configuration()));
 
   @override
-  dispatch(dynamic action) => dispatchedAction = action;
+  void dispatch(dynamic action) => dispatchedAction = action;
 }
 
 class SharedPreferencesSpy extends FlutterSecureStorage {

--- a/test/doubles/stubs.dart
+++ b/test/doubles/stubs.dart
@@ -171,45 +171,45 @@ class AuthWrapperStub extends AuthWrapper {
 
   AuthWrapperStub() : super(DummyFlutterAppAuth(), Lock());
 
-  withLoginArgsResolves(AuthTokenRequest parameters, AuthTokenResponse result) {
+  void withLoginArgsResolves(AuthTokenRequest parameters, AuthTokenResponse result) {
     _loginParameters = parameters;
     _loginResult = result;
     _throwsLoginException = false;
   }
 
-  withLogoutArgsResolves(AuthLogoutRequest parameters) {
+  void withLogoutArgsResolves(AuthLogoutRequest parameters) {
     _logoutParameters = parameters;
     _throwsLogoutException = false;
   }
 
-  withCanceledExcption() {
+  void withCanceledExcption() {
     _throwsCanceledException = true;
   }
 
-  withLoginArgsThrows() {
+  void withLoginArgsThrows() {
     _throwsLoginException = true;
   }
 
-  withLogoutArgsThrows() {
+  void withLogoutArgsThrows() {
     _throwsLogoutException = true;
   }
 
-  withRefreshArgsThrowsNetwork() {
+  void withRefreshArgsThrowsNetwork() {
     _throwsRefreshNetworkException = true;
   }
 
-  withRefreshArgsThrowsExpired() {
+  void withRefreshArgsThrowsExpired() {
     _throwsRefreshNetworkException = false;
     _throwsRefreshExpiredException = true;
   }
 
-  withRefreshArgsThrowsGeneric() {
+  void withRefreshArgsThrowsGeneric() {
     _throwsRefreshNetworkException = false;
     _throwsRefreshExpiredException = false;
     _throwsRefreshGenericException = true;
   }
 
-  withRefreshArgsResolves(AuthRefreshTokenRequest parameters, AuthTokenResponse result) {
+  void withRefreshArgsResolves(AuthRefreshTokenRequest parameters, AuthTokenResponse result) {
     _refreshParameters = parameters;
     _refreshResult = result;
     _throwsRefreshNetworkException = false;

--- a/test/feature/favoris/immersion_favoris_test.dart
+++ b/test/feature/favoris/immersion_favoris_test.dart
@@ -14,7 +14,7 @@ import '../../doubles/fixtures.dart';
 import '../../doubles/stubs.dart';
 import '../../utils/test_setup.dart';
 
-main() {
+void main() {
   test("favori state should be updated when favori is removed and api call succeeds", () async {
     // Given
     final Store<AppState> store = _successStoreWithFavorisAndSearchResultsLoaded();
@@ -57,7 +57,7 @@ main() {
 
   test("favori id list should be updated when favori is added and api call succeeds", () async {
     // Given
-    Store<AppState> store = _successStoreWithFavorisAndSearchResultsLoaded();
+    final Store<AppState> store = _successStoreWithFavorisAndSearchResultsLoaded();
 
     final loadingState =
         store.onChange.any((element) => element.favoriUpdateState.requestStatus["17"] == FavoriUpdateStatus.LOADING);

--- a/test/feature/favoris/offre_emploi_favoris_test.dart
+++ b/test/feature/favoris/offre_emploi_favoris_test.dart
@@ -14,7 +14,7 @@ import '../../doubles/fixtures.dart';
 import '../../doubles/stubs.dart';
 import '../../utils/test_setup.dart';
 
-main() {
+void main() {
   test("favori state should be updated when favori is removed and api call succeeds", () async {
     // Given
     final Store<AppState> store = _successStoreWithFavorisAndSearchResultsLoaded();
@@ -57,7 +57,7 @@ main() {
 
   test("favori id list should be updated when favori is added and api call succeeds", () async {
     // Given
-    Store<AppState> store = _successStoreWithFavorisAndSearchResultsLoaded();
+    final Store<AppState> store = _successStoreWithFavorisAndSearchResultsLoaded();
 
     final loadingState =
         store.onChange.any((element) => element.favoriUpdateState.requestStatus["17"] == FavoriUpdateStatus.LOADING);

--- a/test/feature/favoris/service_civique_favoris_test.dart
+++ b/test/feature/favoris/service_civique_favoris_test.dart
@@ -15,7 +15,7 @@ import '../../doubles/fixtures.dart';
 import '../../doubles/stubs.dart';
 import '../../utils/test_setup.dart';
 
-main() {
+void main() {
   test("favori state should be updated when favori is removed and api call succeeds", () async {
     // Given
     final Store<AppState> store = _successStoreWithFavorisAndSearchResultsLoaded();
@@ -58,7 +58,7 @@ main() {
 
   test("favori id list should be updated when favori is added and api call succeeds", () async {
     // Given
-    Store<AppState> store = _successStoreWithFavorisAndSearchResultsLoaded();
+    final Store<AppState> store = _successStoreWithFavorisAndSearchResultsLoaded();
 
     final loadingState =
         store.onChange.any((element) => element.favoriUpdateState.requestStatus["17"] == FavoriUpdateStatus.LOADING);

--- a/test/feature/immersion/immersion_details_test.dart
+++ b/test/feature/immersion/immersion_details_test.dart
@@ -13,7 +13,7 @@ import '../../doubles/dummies.dart';
 import '../../doubles/fixtures.dart';
 import '../../utils/test_setup.dart';
 
-main() {
+void main() {
   test("immersion should be loaded and result displayed", () async {
     // Given
     final testStoreFactory = TestStoreFactory();

--- a/test/feature/immersion/immersion_filtres_test.dart
+++ b/test/feature/immersion/immersion_filtres_test.dart
@@ -13,7 +13,7 @@ import '../../doubles/fixtures.dart';
 import '../../doubles/stubs.dart';
 import '../../utils/test_setup.dart';
 
-main() {
+void main() {
   test("applying new filtres when call succeeds should replace all existing data and filtres should be stored",
       () async {
     // Given

--- a/test/feature/immersion/immersion_list_test.dart
+++ b/test/feature/immersion/immersion_list_test.dart
@@ -10,7 +10,7 @@ import '../../doubles/fixtures.dart';
 import '../../doubles/stubs.dart';
 import '../../utils/test_setup.dart';
 
-main() {
+void main() {
   test("immersions should be loaded and results displayed", () async {
     // Given
     final testStoreFactory = TestStoreFactory();

--- a/test/feature/location/search_location_test.dart
+++ b/test/feature/location/search_location_test.dart
@@ -9,7 +9,7 @@ import '../../doubles/dummies.dart';
 import '../../doubles/fixtures.dart';
 import '../../utils/test_setup.dart';
 
-main() {
+void main() {
   test("Returns locations list when user search location", () async {
     // Given
     final factory = TestStoreFactory();

--- a/test/feature/login/post_login_get_favoris_test.dart
+++ b/test/feature/login/post_login_get_favoris_test.dart
@@ -10,7 +10,7 @@ import '../../doubles/fixtures.dart';
 import '../../utils/test_setup.dart';
 import '../favoris/offre_emploi_favoris_test.dart';
 
-main() {
+void main() {
   test("after login, favoris id should be loaded", () async {
     // Given
     final initialState = AppState.initialState().copyWith(loginState: LoginFailureState());

--- a/test/feature/login/post_login_init_chat_with_firebase_token_test.dart
+++ b/test/feature/login/post_login_init_chat_with_firebase_token_test.dart
@@ -14,7 +14,7 @@ import '../../doubles/fixtures.dart';
 import '../../doubles/stubs.dart';
 import '../../utils/test_setup.dart';
 
-main() {
+void main() {
   group("after login ...", () {
     group('when coming from a chat deep link…', () {
       final initialState = AppState.initialState().copyWith(

--- a/test/feature/login/post_login_init_pole_emploi_token_test.dart
+++ b/test/feature/login/post_login_init_pole_emploi_token_test.dart
@@ -11,7 +11,7 @@ import '../../doubles/dummies.dart';
 import '../../doubles/fixtures.dart';
 import '../../utils/test_setup.dart';
 
-main() {
+void main() {
   group("after login ...", () {
     test("with a Pole Emploi user, Pole Emploi token should be fetched and set", () async {
       // Given

--- a/test/feature/login/post_login_register_push_token_test.dart
+++ b/test/feature/login/post_login_register_push_token_test.dart
@@ -10,7 +10,7 @@ import '../../doubles/fixtures.dart';
 import '../../utils/test_setup.dart';
 import '../favoris/offre_emploi_favoris_test.dart';
 
-main() {
+void main() {
   test("push notification token should be registered", () async {
     // Given
     final initialState = AppState.initialState().copyWith(loginState: LoginFailureState());

--- a/test/feature/login/post_logout_clear_pole_emploi_token_test.dart
+++ b/test/feature/login/post_logout_clear_pole_emploi_token_test.dart
@@ -7,7 +7,7 @@ import 'package:redux/src/store.dart';
 import '../../doubles/fixtures.dart';
 import '../../utils/test_setup.dart';
 
-main() {
+void main() {
   test("After logout Pole Emploi auth token should be cleared", () async {
     // Given
     final initialState = AppState.initialState().copyWith(loginState: successPoleEmploiUserState());

--- a/test/feature/login/post_logout_sign_out_from_firebase_test.dart
+++ b/test/feature/login/post_logout_sign_out_from_firebase_test.dart
@@ -6,7 +6,7 @@ import 'package:redux/src/store.dart';
 
 import '../../utils/test_setup.dart';
 
-main() {
+void main() {
   test("After logout user should be signed out from Firebase Auth", () async {
     // Given
     final testStoreFactory = TestStoreFactory();

--- a/test/feature/metier/search_metier_test.dart
+++ b/test/feature/metier/search_metier_test.dart
@@ -8,7 +8,7 @@ import 'package:pass_emploi_app/repositories/metier_repository.dart';
 import '../../doubles/fixtures.dart';
 import '../../utils/test_setup.dart';
 
-main() {
+void main() {
   test("Returns metiers list when user search metier", () async {
     // Given
     final factory = TestStoreFactory();

--- a/test/feature/offre_emploi/offre_emploi_details_test.dart
+++ b/test/feature/offre_emploi/offre_emploi_details_test.dart
@@ -12,7 +12,7 @@ import '../../doubles/dummies.dart';
 import '../../doubles/fixtures.dart';
 import '../../utils/test_setup.dart';
 
-main() {
+void main() {
   test("detailed offer should be fetched and displayed when screen loads", () async {
     // Given
     final testStoreFactory = TestStoreFactory();

--- a/test/feature/offre_emploi/offre_emploi_filtres_test.dart
+++ b/test/feature/offre_emploi/offre_emploi_filtres_test.dart
@@ -13,7 +13,7 @@ import '../../doubles/fixtures.dart';
 import '../../doubles/stubs.dart';
 import '../../utils/test_setup.dart';
 
-main() {
+void main() {
   test("applying new filtres when call succeeds should replace all existing data and filtres should be stored",
       () async {
     // Given

--- a/test/feature/offre_emploi/offre_emploi_list_test.dart
+++ b/test/feature/offre_emploi/offre_emploi_list_test.dart
@@ -11,7 +11,7 @@ import '../../doubles/fixtures.dart';
 import '../../doubles/stubs.dart';
 import '../../utils/test_setup.dart';
 
-main() {
+void main() {
   group("offre emplois when data has already been loaded ...", () {
     test("and new call succeeds should append newly loaded data to existing list and set new page number", () async {
       // Given
@@ -42,7 +42,7 @@ main() {
       final appState = await successState;
       expect(appState.offreEmploiSearchState is OffreEmploiSearchSuccessState, true);
 
-      var searchResultsState = (appState.offreEmploiListState as OffreEmploiListSuccessState);
+      final searchResultsState = (appState.offreEmploiListState as OffreEmploiListSuccessState);
       expect(searchResultsState.offres.length, 2);
       expect(searchResultsState.loadedPage, 2);
     });
@@ -76,7 +76,7 @@ main() {
       final appState = await errorState;
       expect(appState.offreEmploiSearchState is OffreEmploiSearchFailureState, true);
 
-      var searchResultsState = (appState.offreEmploiListState as OffreEmploiListSuccessState);
+      final searchResultsState = (appState.offreEmploiListState as OffreEmploiListSuccessState);
       expect(searchResultsState.offres.length, 1);
       expect(searchResultsState.loadedPage, 1);
       expect(searchResultsState.isMoreDataAvailable, true);
@@ -108,7 +108,7 @@ main() {
       final appState = await successState;
       expect(appState.offreEmploiSearchState is OffreEmploiSearchSuccessState, true);
 
-      var searchResultsState = (appState.offreEmploiListState as OffreEmploiListSuccessState);
+      final searchResultsState = (appState.offreEmploiListState as OffreEmploiListSuccessState);
       expect(searchResultsState.offres.length, 2);
       expect(searchResultsState.loadedPage, 2);
       expect(searchResultsState.isMoreDataAvailable, false);
@@ -173,7 +173,7 @@ main() {
         final appState = await errorState;
         expect(appState.offreEmploiSearchState is OffreEmploiSearchFailureState, true);
 
-        var searchResultsState = (appState.offreEmploiListState as OffreEmploiListSuccessState);
+        final searchResultsState = (appState.offreEmploiListState as OffreEmploiListSuccessState);
         expect(searchResultsState.offres.length, 1);
         expect(searchResultsState.loadedPage, 1);
       });
@@ -208,7 +208,7 @@ main() {
         final appState = await successState;
         expect(appState.offreEmploiSearchState is OffreEmploiSearchSuccessState, true);
 
-        var searchResultsState = (appState.offreEmploiListState as OffreEmploiListSuccessState);
+        final searchResultsState = (appState.offreEmploiListState as OffreEmploiListSuccessState);
         expect(searchResultsState.offres.length, 2);
         expect(searchResultsState.loadedPage, 2);
       });

--- a/test/feature/offre_emploi/offre_emploi_search_test.dart
+++ b/test/feature/offre_emploi/offre_emploi_search_test.dart
@@ -8,7 +8,7 @@ import '../../doubles/fixtures.dart';
 import '../../doubles/stubs.dart';
 import '../../utils/test_setup.dart';
 
-main() {
+void main() {
   test("offres emploi should be loaded, results displayed, and parameters saved", () async {
     // Given
     final factory = TestStoreFactory();

--- a/test/feature/saved_search/immersion_saved_search_test.dart
+++ b/test/feature/saved_search/immersion_saved_search_test.dart
@@ -20,7 +20,7 @@ import '../../doubles/stubs.dart';
 import '../../utils/test_setup.dart';
 import '../immersion/immersion_list_test.dart';
 
-main() {
+void main() {
   group("When user tries to save an offer search ...", () {
     final immersionSavedSearch = ImmersionSavedSearch(
       id: "id",
@@ -32,7 +32,7 @@ main() {
       codeRome: "ROME-PARIS",
     );
 
-    AppState initialState = AppState.initialState().copyWith(
+    final AppState initialState = AppState.initialState().copyWith(
       immersionSavedSearchCreateState: SavedSearchCreateState.initialized(immersionSavedSearch),
       loginState: successMiloUserState(),
     );
@@ -51,7 +51,7 @@ main() {
       store.dispatch(SavedSearchCreateRequestAction(immersionSavedSearch, "Boulanger - Paris"));
 
       // Then
-      var immersionSavedSearchState = (await expected).immersionSavedSearchCreateState;
+      final immersionSavedSearchState = (await expected).immersionSavedSearchCreateState;
       expect(immersionSavedSearchState is SavedSearchCreateSuccessfullyCreated, true);
     });
 
@@ -69,13 +69,13 @@ main() {
       store.dispatch(SavedSearchCreateRequestAction(immersionSavedSearch, "Boulanger - Paris"));
 
       // Then
-      var immersionSavedSearchState = (await expected).immersionSavedSearchCreateState;
+      final immersionSavedSearchState = (await expected).immersionSavedSearchCreateState;
       expect(immersionSavedSearchState is SavedSearchCreateFailureState, true);
     });
 
     test("SaveSearchInitializeAction should update store with rights information", () async {
       // Given
-      AppState initialState = AppState.initialState().copyWith(
+      final AppState initialState = AppState.initialState().copyWith(
         immersionListState: ImmersionListSuccessState([
           Immersion(
               id: "id",
@@ -119,7 +119,7 @@ main() {
 
     test("SaveSearchInitializeAction should update store with rights information when search has filtres", () async {
       // Given
-      AppState initialState = AppState.initialState().copyWith(
+      final AppState initialState = AppState.initialState().copyWith(
         immersionListState: ImmersionListSuccessState([
           Immersion(
             id: "id",
@@ -164,7 +164,7 @@ main() {
 
     test("SaveSearchInitializeAction should update store with right information when search has no result", () async {
       // Given
-      AppState initialState = AppState.initialState().copyWith(
+      final AppState initialState = AppState.initialState().copyWith(
         immersionListState: ImmersionListSuccessState([]),
         immersionSearchParametersState: ImmersionSearchParametersInitializedState(
           codeRome: "codeRome",

--- a/test/feature/saved_search/offre_emploi_saved_search_test.dart
+++ b/test/feature/saved_search/offre_emploi_saved_search_test.dart
@@ -15,7 +15,7 @@ import '../../doubles/fixtures.dart';
 import '../../doubles/stubs.dart';
 import '../../utils/test_setup.dart';
 
-main() {
+void main() {
   group("When user tries to save an offer search ...", () {
     final offreEmploiSavedSearch = OffreEmploiSavedSearch(
         id: "id",
@@ -26,7 +26,7 @@ main() {
         location: mockLocation(),
         metier: "Boulanger");
 
-    AppState initialState = AppState.initialState().copyWith(
+    final AppState initialState = AppState.initialState().copyWith(
       offreEmploiSavedSearchCreateState: SavedSearchCreateState.initialized(offreEmploiSavedSearch),
       loginState: successMiloUserState(),
     );
@@ -45,7 +45,7 @@ main() {
       store.dispatch(SavedSearchCreateRequestAction(offreEmploiSavedSearch, "Boulanger"));
 
       // Then
-      var offreEmploiSavedSearchCreateState = (await expected).offreEmploiSavedSearchCreateState;
+      final offreEmploiSavedSearchCreateState = (await expected).offreEmploiSavedSearchCreateState;
       expect(offreEmploiSavedSearchCreateState is SavedSearchCreateSuccessfullyCreated, true);
     });
 

--- a/test/feature/saved_search/saved_search_delete_test.dart
+++ b/test/feature/saved_search/saved_search_delete_test.dart
@@ -11,7 +11,7 @@ import '../../doubles/dummies.dart';
 import '../../doubles/fixtures.dart';
 import '../../utils/test_setup.dart';
 
-main() {
+void main() {
   group("When repository succeeds…", () {
     final testStoreFactory = TestStoreFactory();
     testStoreFactory.savedSearchDeleteRepository = SavedSearchDeleteRepositorySuccessStub();

--- a/test/feature/service_civique/service_civique_detail_test.dart
+++ b/test/feature/service_civique/service_civique_detail_test.dart
@@ -6,7 +6,7 @@ import '../../doubles/fixtures.dart';
 import '../../doubles/stubs.dart';
 import '../../utils/test_setup.dart';
 
-main() {
+void main() {
   test("service civique detail should be loaded when asked", () async {
     final factory = TestStoreFactory();
     factory.serviceCiviqueDetailRepository = ServiceCiviqueDetailRepositoryWithDataStub();

--- a/test/feature/service_civique_test.dart
+++ b/test/feature/service_civique_test.dart
@@ -108,7 +108,7 @@ void main() {
     );
 
     final successState = store.onChange.firstWhere((e) {
-      var state = e.serviceCiviqueSearchResultState;
+      final state = e.serviceCiviqueSearchResultState;
       return state is ServiceCiviqueSearchResultDataState && state.offres.isNotEmpty;
     });
 

--- a/test/feature/service_civique_test.dart
+++ b/test/feature/service_civique_test.dart
@@ -8,7 +8,7 @@ import '../doubles/fixtures.dart';
 import '../doubles/stubs.dart';
 import '../utils/test_setup.dart';
 
-main() {
+void main() {
   test("service civique should be loaded", () async {
     // Given
     final factory = TestStoreFactory();

--- a/test/feature/user_action/user_action_create_test.dart
+++ b/test/feature/user_action/user_action_create_test.dart
@@ -8,7 +8,7 @@ import '../../doubles/fixtures.dart';
 import '../../doubles/stubs.dart';
 import '../../utils/test_setup.dart';
 
-main() {
+void main() {
   test("create user action when repo succeeds should display loading and then create user action", () async {
     // Given
     final testStoreFactory = TestStoreFactory();

--- a/test/feature/user_action/user_action_delete_test.dart
+++ b/test/feature/user_action/user_action_delete_test.dart
@@ -9,7 +9,7 @@ import 'package:pass_emploi_app/redux/app_state.dart';
 import '../../doubles/stubs.dart';
 import '../../utils/test_setup.dart';
 
-main() {
+void main() {
   test("delete user action when repo succeeds should display loading and then delete user action", () async {
     // Given
     final testStoreFactory = TestStoreFactory();

--- a/test/models/message_test.dart
+++ b/test/models/message_test.dart
@@ -5,7 +5,7 @@ import 'package:pass_emploi_app/repositories/crypto/chat_crypto.dart';
 
 import '../doubles/dummies.dart';
 
-main() {
+void main() {
   test("toJson when message has encrypted content should decrypt it", () {
     // Given
     final chatCryptoSpy = _ChatCryptoSpy();

--- a/test/models/user_action_test.dart
+++ b/test/models/user_action_test.dart
@@ -7,7 +7,7 @@ import 'package:pass_emploi_app/models/user_action_creator.dart';
 import '../utils/test_assets.dart';
 import '../utils/test_datetime.dart';
 
-main() {
+void main() {
   test('UserAction.fromJson when complete data should deserialize data correctly with date on local timezone', () {
     // Given
     final String userActionString = loadTestAssets("user_action.json");

--- a/test/presentation/choix_organisme_explaination_view_model_test.dart
+++ b/test/presentation/choix_organisme_explaination_view_model_test.dart
@@ -7,7 +7,7 @@ import 'package:redux/redux.dart';
 
 import '../doubles/spies.dart';
 
-main() {
+void main() {
   test("create should set proper text when user chose Pole Emploi", () {
     // Given
     final state = AppState.initialState();

--- a/test/presentation/favoris/immersion_favori_heart_view_model_test.dart
+++ b/test/presentation/favoris/immersion_favori_heart_view_model_test.dart
@@ -7,7 +7,7 @@ import 'package:pass_emploi_app/redux/app_reducer.dart';
 import 'package:pass_emploi_app/redux/app_state.dart';
 import 'package:redux/redux.dart';
 
-main() {
+void main() {
   test("create when id is in favori list should set isFavori to true", () {
     // Given
     final store = Store<AppState>(

--- a/test/presentation/favoris/immersion_favori_list_view_model_test.dart
+++ b/test/presentation/favoris/immersion_favori_list_view_model_test.dart
@@ -11,7 +11,7 @@ import 'package:redux/redux.dart';
 import '../../doubles/fixtures.dart';
 import '../../doubles/spies.dart';
 
-main() {
+void main() {
   test("create when favoris have data should show content", () {
     // Given
     final store = Store<AppState>(

--- a/test/presentation/favoris/offre_emploi_favori_heart_view_model_test.dart
+++ b/test/presentation/favoris/offre_emploi_favori_heart_view_model_test.dart
@@ -7,7 +7,7 @@ import 'package:pass_emploi_app/redux/app_reducer.dart';
 import 'package:pass_emploi_app/redux/app_state.dart';
 import 'package:redux/redux.dart';
 
-main() {
+void main() {
   test("create when id is in favori list should set isFavori to true", () {
     // Given
     final store = Store<AppState>(

--- a/test/presentation/favoris/offre_emploi_favori_list_view_model_test.dart
+++ b/test/presentation/favoris/offre_emploi_favori_list_view_model_test.dart
@@ -11,7 +11,7 @@ import 'package:redux/redux.dart';
 import '../../doubles/fixtures.dart';
 import '../../doubles/spies.dart';
 
-main() {
+void main() {
   group('create when not only alternance…', () {
     test("and favoris have data should show content", () {
       // Given

--- a/test/presentation/immersion/immersion_filtres_view_model_test.dart
+++ b/test/presentation/immersion/immersion_filtres_view_model_test.dart
@@ -12,7 +12,7 @@ import 'package:redux/redux.dart';
 import '../../doubles/fixtures.dart';
 import '../../doubles/spies.dart';
 
-main() {
+void main() {
   test("create when search state is success should display success", () {
     // Given
     final store = Store<AppState>(

--- a/test/presentation/immersion/immersion_search_results_view_model_test.dart
+++ b/test/presentation/immersion/immersion_search_results_view_model_test.dart
@@ -10,7 +10,7 @@ import 'package:redux/redux.dart';
 
 import '../../doubles/fixtures.dart';
 
-main() {
+void main() {
   test("create when state is success should convert data to view model", () {
     // Given
     final store = Store<AppState>(

--- a/test/presentation/immersion_details_view_model_test.dart
+++ b/test/presentation/immersion_details_view_model_test.dart
@@ -15,7 +15,7 @@ import 'package:redux/redux.dart';
 
 import '../doubles/spies.dart';
 
-main() {
+void main() {
   test('create when state is loading should set display state properly', () {
     // Given
     final store = _store(ImmersionDetailsLoadingState());

--- a/test/presentation/immersion_search_view_model_test.dart
+++ b/test/presentation/immersion_search_view_model_test.dart
@@ -16,7 +16,7 @@ import 'package:redux/redux.dart';
 import '../doubles/fixtures.dart';
 import '../doubles/spies.dart';
 
-main() {
+void main() {
   test("create when state is loading should set display state properly", () {
     // Given
     final store = Store<AppState>(

--- a/test/presentation/offre_emploi_details_page_view_model_test.dart
+++ b/test/presentation/offre_emploi_details_page_view_model_test.dart
@@ -7,7 +7,7 @@ import 'package:redux/redux.dart';
 
 import '../doubles/fixtures.dart';
 
-main() {
+void main() {
   test("getDetails when state is loading should set display state properly", () {
     // Given
     final store = Store<AppState>(

--- a/test/presentation/offre_emploi_filtres_view_model_test.dart
+++ b/test/presentation/offre_emploi_filtres_view_model_test.dart
@@ -14,7 +14,7 @@ import 'package:redux/redux.dart';
 import '../doubles/fixtures.dart';
 import '../doubles/spies.dart';
 
-main() {
+void main() {
   test("create when search state is success should display success", () {
     // Given
     final store = Store<AppState>(

--- a/test/presentation/offre_emploi_search_results_view_model_test.dart
+++ b/test/presentation/offre_emploi_search_results_view_model_test.dart
@@ -12,7 +12,7 @@ import 'package:redux/redux.dart';
 
 import '../doubles/fixtures.dart';
 
-main() {
+void main() {
   group("create when state is success should convert data to view model", () {
     Store<AppState> _successSetUp({required bool moreData}) {
       final store = Store<AppState>(
@@ -278,7 +278,7 @@ main() {
   group("Filtre button…", () {
     test('when search is not only for alternance should be displayed', () {
       // Given
-      Store<AppState> store = _storeWithParams(onlyAlternance: false, location: null);
+      final Store<AppState> store = _storeWithParams(onlyAlternance: false, location: null);
 
       // When
       final viewModel = OffreEmploiSearchResultsViewModel.create(store);
@@ -290,7 +290,7 @@ main() {
     group('when search is only for alternance…', () {
       test('and location is null should not be displayed', () {
         // Given
-        Store<AppState> store = _storeWithParams(onlyAlternance: true, location: null);
+        final Store<AppState> store = _storeWithParams(onlyAlternance: true, location: null);
 
         // When
         final viewModel = OffreEmploiSearchResultsViewModel.create(store);
@@ -301,7 +301,7 @@ main() {
 
       test('and location is DEPARTMENT should not be displayed', () {
         // Given
-        Store<AppState> store = _storeWithParams(
+        final Store<AppState> store = _storeWithParams(
           onlyAlternance: true,
           location: Location(libelle: '', code: '', type: LocationType.DEPARTMENT),
         );
@@ -315,7 +315,7 @@ main() {
 
       test('and location is COMMUNE should be displayed', () {
         // Given
-        Store<AppState> store = _storeWithParams(
+        final Store<AppState> store = _storeWithParams(
           onlyAlternance: true,
           location: Location(libelle: '', code: '', type: LocationType.COMMUNE),
         );

--- a/test/presentation/offre_emploi_search_view_model_test.dart
+++ b/test/presentation/offre_emploi_search_view_model_test.dart
@@ -14,7 +14,7 @@ import 'package:redux/redux.dart';
 import '../doubles/fixtures.dart';
 import '../doubles/spies.dart';
 
-main() {
+void main() {
   test("create when state is loading should set display state properly", () {
     // Given
     final store = Store<AppState>(

--- a/test/presentation/profil_page_view_model_test.dart
+++ b/test/presentation/profil_page_view_model_test.dart
@@ -7,7 +7,7 @@ import 'package:pass_emploi_app/redux/app_state.dart';
 
 import '../utils/test_setup.dart';
 
-main() {
+void main() {
   test("create should properly set user info", () {
     // Given
     final store = TestStoreFactory().initializeReduxStore(

--- a/test/presentation/rendezvous/rendezvous_card_view_model_test.dart
+++ b/test/presentation/rendezvous/rendezvous_card_view_model_test.dart
@@ -9,7 +9,7 @@ import 'package:redux/redux.dart';
 import '../../doubles/fixtures.dart';
 import '../../utils/test_setup.dart';
 
-main() {
+void main() {
   test('create when rendezvous state is not successful throws exception', () {
     // Given
     final store = TestStoreFactory().initializeReduxStore(

--- a/test/presentation/rendezvous/rendezvous_details_view_model_test.dart
+++ b/test/presentation/rendezvous/rendezvous_details_view_model_test.dart
@@ -11,7 +11,7 @@ import 'package:redux/redux.dart';
 import '../../doubles/fixtures.dart';
 import '../../utils/test_setup.dart';
 
-main() {
+void main() {
   test('create when rendezvous state is not successful throws exception', () {
     // Given
     final store = TestStoreFactory().initializeReduxStore(

--- a/test/presentation/rendezvous/rendezvous_list_view_model_test.dart
+++ b/test/presentation/rendezvous/rendezvous_list_view_model_test.dart
@@ -13,7 +13,7 @@ import '../../doubles/fixtures.dart';
 import '../../doubles/spies.dart';
 import '../../utils/test_setup.dart';
 
-main() {
+void main() {
   test('create when rendezvous state is loading should display loading', () {
     // Given
     final store = TestStoreFactory().initializeReduxStore(

--- a/test/presentation/saved_search/saved_search_delete_view_model_test.dart
+++ b/test/presentation/saved_search/saved_search_delete_view_model_test.dart
@@ -7,7 +7,7 @@ import 'package:pass_emploi_app/redux/app_state.dart';
 import '../../doubles/spies.dart';
 import '../../utils/test_setup.dart';
 
-main() {
+void main() {
   test('create when saved search delete state is not initialized should display content', () {
     // Given
     final store = TestStoreFactory().initializeReduxStore(

--- a/test/presentation/saved_search/saved_search_list_view_model_test.dart
+++ b/test/presentation/saved_search/saved_search_list_view_model_test.dart
@@ -15,7 +15,7 @@ import 'package:pass_emploi_app/redux/app_state.dart';
 import '../../doubles/fixtures.dart';
 import '../../utils/test_setup.dart';
 
-main() {
+void main() {
   final List<SavedSearch> _savedSearches = [
     ImmersionSavedSearch(
       id: "id",

--- a/test/presentation/search_extractor_test.dart
+++ b/test/presentation/search_extractor_test.dart
@@ -15,19 +15,19 @@ import 'package:pass_emploi_app/redux/app_state.dart';
 import '../doubles/fixtures.dart';
 import '../utils/test_setup.dart';
 
-main() {
+void main() {
   test("tests offre emploi search extractor", () {
     // Given
     final testStoreFactory = TestStoreFactory();
-    var filtres = OffreEmploiSearchParametersFiltres.withFiltres(
+    final filtres = OffreEmploiSearchParametersFiltres.withFiltres(
       distance: 12,
       experience: [ExperienceFiltre.de_un_a_trois_ans],
       duree: [DureeFiltre.temps_partiel],
       contrat: [ContratFiltre.cdd_interim_saisonnier],
     );
-    OffreEmploiSearchParametersState searchParametersState = OffreEmploiSearchParametersState.initialized(
+    final OffreEmploiSearchParametersState searchParametersState = OffreEmploiSearchParametersState.initialized(
         keywords: "Je suis un keyword", location: mockLocation(), onlyAlternance: false, filtres: filtres);
-    AppState state = AppState.initialState().copyWith(
+    final AppState state = AppState.initialState().copyWith(
       offreEmploiSearchParametersState: searchParametersState,
     );
     final store = testStoreFactory.initializeReduxStore(initialState: state);
@@ -61,7 +61,7 @@ main() {
       )
     ]);
     final searchedMetier = Metier.values.first;
-    AppState state = AppState.initialState().copyWith(
+    final AppState state = AppState.initialState().copyWith(
       searchMetierState: SearchMetierState([searchedMetier]),
       immersionListState: immersionState,
       immersionSearchParametersState: ImmersionSearchParametersInitializedState(
@@ -102,7 +102,7 @@ main() {
           ville: "ville"),
     ]);
     final searchedMetier = Metier.values.first;
-    AppState state = AppState.initialState().copyWith(
+    final AppState state = AppState.initialState().copyWith(
       searchMetierState: SearchMetierState([searchedMetier]),
       immersionListState: immersionState,
       immersionSearchParametersState: ImmersionSearchParametersInitializedState(

--- a/test/presentation/service_civique/service_civique_detail_view_model_test.dart
+++ b/test/presentation/service_civique/service_civique_detail_view_model_test.dart
@@ -9,7 +9,7 @@ import 'package:redux/redux.dart';
 
 import '../../doubles/fixtures.dart';
 
-main() {
+void main() {
   test("create when state is loading should set display state to loading", () {
     // Given
     final state = AppState.initialState().copyWith(serviceCiviqueDetailState: ServiceCiviqueDetailLoadingState());

--- a/test/presentation/user_action/user_action_create_view_model_test.dart
+++ b/test/presentation/user_action/user_action_create_view_model_test.dart
@@ -7,7 +7,7 @@ import 'package:pass_emploi_app/redux/app_reducer.dart';
 import 'package:pass_emploi_app/redux/app_state.dart';
 import 'package:redux/redux.dart';
 
-main() {
+void main() {
   test("create when state is loading should set display state to loading", () {
     // Given
     final state = AppState.initialState().copyWith(userActionCreateState: UserActionCreateLoadingState());

--- a/test/presentation/user_action/user_action_details_view_model_test.dart
+++ b/test/presentation/user_action/user_action_details_view_model_test.dart
@@ -12,7 +12,7 @@ import 'package:redux/redux.dart';
 
 import '../../doubles/fixtures.dart';
 
-main() {
+void main() {
   group("create when action has been updated ...", () {
     test("to not_started status should dismiss bottom sheet", () {
       // Given
@@ -135,7 +135,7 @@ main() {
 
   test('refreshStatus when update status has changed should dispatch a UpdateActionStatus', () {
     // Given
-    var storeSpy = StoreSpy();
+    final storeSpy = StoreSpy();
     final store = Store<AppState>(
       storeSpy.reducer,
       initialState: loggedInState().copyWith(
@@ -172,7 +172,7 @@ main() {
 
   test('refreshStatus when update status has not changed should dispatch UserActionNoUpdateNeededAction', () {
     // Given
-    var storeSpy = StoreSpy();
+    final storeSpy = StoreSpy();
     final store = Store<AppState>(
       storeSpy.reducer,
       initialState: loggedInState().copyWith(

--- a/test/presentation/user_action/user_action_list_page_view_model_test.dart
+++ b/test/presentation/user_action/user_action_list_page_view_model_test.dart
@@ -13,7 +13,7 @@ import 'package:redux/redux.dart';
 
 import '../../doubles/fixtures.dart';
 
-main() {
+void main() {
   test('create when action state is loading should display loader', () {
     // Given
     final store = Store<AppState>(
@@ -61,7 +61,7 @@ main() {
 
   test('retry, after view model was created with failure, should dispatch a RequestUserActionsAction', () {
     // Given
-    var storeSpy = StoreSpy();
+    final storeSpy = StoreSpy();
     final store = Store<AppState>(
       storeSpy.reducer,
       initialState: loggedInState().copyWith(userActionListState: UserActionListFailureState()),
@@ -188,7 +188,7 @@ main() {
 
   test('onUserActionDetailsDismissed should dispatch DismissUserActionDetailsAction', () {
     // Given
-    var storeSpy = StoreSpy();
+    final storeSpy = StoreSpy();
     final store = Store<AppState>(
       storeSpy.reducer,
       initialState: loggedInState(),
@@ -205,7 +205,7 @@ main() {
 
   test('onCreateUserActionDismissed should dispatch DismissCreateUserAction', () {
     // Given
-    var storeSpy = StoreSpy();
+    final storeSpy = StoreSpy();
     final store = Store<AppState>(
       storeSpy.reducer,
       initialState: loggedInState(),

--- a/test/presentation/user_action/user_action_view_model_test.dart
+++ b/test/presentation/user_action/user_action_view_model_test.dart
@@ -5,7 +5,7 @@ import 'package:pass_emploi_app/presentation/user_action/user_action_view_model.
 import 'package:pass_emploi_app/ui/app_colors.dart';
 import 'package:pass_emploi_app/ui/strings.dart';
 
-main() {
+void main() {
   test("UserActionViewModel.create when creator is jeune should create view model properly", () {
     // Given
     final userAction = UserAction(

--- a/test/repositories/crypto/chat_crypto_test.dart
+++ b/test/repositories/crypto/chat_crypto_test.dart
@@ -3,8 +3,7 @@ import 'dart:convert';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:pass_emploi_app/repositories/crypto/chat_crypto.dart';
 
-main() {
-
+void main() {
   test("chat crypto should encrypt message and then decrypt it", () {
     // Given
     const String message = "mon super message";

--- a/test/repositories/favoris/immersion_favoris_repository_test.dart
+++ b/test/repositories/favoris/immersion_favoris_repository_test.dart
@@ -9,7 +9,7 @@ import '../../doubles/fixtures.dart';
 import '../../doubles/stubs.dart';
 import '../../utils/test_assets.dart';
 
-main() {
+void main() {
   test('getFavorisId when response is valid with all parameters should return offres', () async {
     // Given
     final httpClient = MockClient((request) async {

--- a/test/repositories/favoris/offre_emploi_favoris_repository_test.dart
+++ b/test/repositories/favoris/offre_emploi_favoris_repository_test.dart
@@ -9,7 +9,7 @@ import '../../doubles/fixtures.dart';
 import '../../doubles/stubs.dart';
 import '../../utils/test_assets.dart';
 
-main() {
+void main() {
   test('getFavorisId when response is valid with all parameters should return offres', () async {
     // Given
     final httpClient = MockClient((request) async {

--- a/test/repositories/favoris/service_civique_favoris_repository_test.dart
+++ b/test/repositories/favoris/service_civique_favoris_repository_test.dart
@@ -9,7 +9,7 @@ import '../../doubles/fixtures.dart';
 import '../../doubles/stubs.dart';
 import '../../utils/test_assets.dart';
 
-main() {
+void main() {
   test('getFavorisId when response is valid with all parameters should return offres', () async {
     // Given
     final httpClient = MockClient((request) async {

--- a/test/repositories/metier_repository_test.dart
+++ b/test/repositories/metier_repository_test.dart
@@ -2,7 +2,7 @@ import 'package:flutter_test/flutter_test.dart';
 import 'package:pass_emploi_app/models/metier.dart';
 import 'package:pass_emploi_app/repositories/metier_repository.dart';
 
-main() {
+void main() {
   group("_getMetiers should return ...", () {
     final MetierRepository repository = MetierRepository();
 

--- a/test/repositories/saved_search/get_saved_search_repository_test.dart
+++ b/test/repositories/saved_search/get_saved_search_repository_test.dart
@@ -13,7 +13,7 @@ import '../../doubles/fixtures.dart';
 import '../../doubles/stubs.dart';
 import '../../utils/test_assets.dart';
 
-main() {
+void main() {
   group("When user want to get a saved search list, getSavedSearch should ...", () {
     test('return saved search offers when response is valid with all parameters', () async {
       // Given

--- a/test/repositories/saved_search/immersion_saved_search_repository_test.dart
+++ b/test/repositories/saved_search/immersion_saved_search_repository_test.dart
@@ -9,7 +9,7 @@ import 'package:pass_emploi_app/repositories/saved_search/immersion_saved_search
 import '../../doubles/fixtures.dart';
 import '../../doubles/stubs.dart';
 
-main() {
+void main() {
   group("When user save new search postSavedSearch should ...", () {
     test("successfully send request when all fields and filters are full and return TRUE if response is valid (201)",
         () async {

--- a/test/repositories/saved_search/offre_emploi_saved_search_repository_test.dart
+++ b/test/repositories/saved_search/offre_emploi_saved_search_repository_test.dart
@@ -10,7 +10,7 @@ import 'package:pass_emploi_app/repositories/saved_search/offre_emploi_saved_sea
 import '../../doubles/fixtures.dart';
 import '../../doubles/stubs.dart';
 
-main() {
+void main() {
   group("When user save new search postSavedSearch should ...", () {
     test(
         "successfully send request when all fields are null - except Title Field - and return TRUE if response is valid (201)",

--- a/test/repositories/saved_search/saved_search_delete_repository_test.dart
+++ b/test/repositories/saved_search/saved_search_delete_repository_test.dart
@@ -6,7 +6,7 @@ import 'package:pass_emploi_app/repositories/saved_search/saved_search_delete_re
 import '../../doubles/fixtures.dart';
 import '../../doubles/stubs.dart';
 
-main() {
+void main() {
   test('delete should return true when response is valid with proper parameters', () async {
     // Given
     final httpClient = MockClient((request) async {


### PR DESCRIPTION
A lire en 2 temps : 

Premier commit : le `analysis_options.yaml`

Alors, j'ai creusé un peu plus cette histoire de `flutter analyze`, et de ma compréhension, les 2 blocs `linter ` et `analyzer` ont 2 rôles différents : 
- `linter` flague les checks comme activés ou non 
- `analyzer` gère la sévérité des erreurs 

Et du coup j'ai l'impression que les flags qu'on avait mis dans `analyzer` n'étaient pas déclenchés parce que pas activés dans le `linter`.

Et pour info, j'ai enlevé le `prefer_double_quotes`. Dans la théorie je suis archi pour, mais dans la pratique c'est super relou, lorsque Android Studio ajoute un import, il le fait par défaut avec des single quotes ... Du coup faut aller chercher les imports et les changer à la mano 😢 

Deuxième commit : tous les changements pour régler les problèmes.
Rien de spécial à signaler, assez simple à faire en utilisant l'onglet "Dart Analysis" en bas dans AS.
