### PR TITLE
[FIX] 484 - Plantage Firestore Android en prod

### DIFF
--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -61,6 +61,10 @@ android {
     buildTypes {
         release {
             signingConfig signingConfigs.release
+            // In order to fix "[CLOUD_FIRESTORE] The service is currently unavailable" issue
+            // https://github.com/firebase/flutterfire/discussions/5708#discussioncomment-925997
+            shrinkResources false
+            minifyEnabled false
         }
     }
 

--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -2,6 +2,8 @@
     xmlns:tools="http://schemas.android.com/tools"
     package="fr.fabrique.social.gouv.pass_emploi_app">
 
+    <uses-permission android:name="android.permission.INTERNET" />
+
     <application
         android:fullBackupContent="@xml/backup_rules"
         android:icon="@mipmap/ic_launcher"


### PR DESCRIPTION
Pas super sûr de comprendre en quoi ça fonctionne…

Mais les retours [sont exactement ceux-ci](git push --set-upstream origin fix/484-plantage-en-prod-transactionstreamhandlerjava), et ça à l'air de fonctionner pour tout le monde…

Et pour une fois qu'on peux mettre le `minifyEnabled` à `false` sans que ça pose de soucis, autant tester :)