### PR TITLE
[TECH][DO NOT MERGE] use navigator observer for simple routes

### DIFF
--- a/lib/analytics/analytics_extensions.dart
+++ b/lib/analytics/analytics_extensions.dart
@@ -1,7 +1,7 @@
 import 'package:flutter/material.dart';
 import 'package:matomo/matomo.dart';
 
-extension TraceableStatelessWidgetExtension on StatelessWidget {
+extension StatelessWidgetAnalyticsExtension on StatelessWidget {
   Future<T?> pushAndTrackBack<T>(BuildContext context, Route<T> route, String name) {
     return Navigator.push(context, route).then((value) {
       MatomoTracker.trackScreenWithName(name, "");
@@ -10,7 +10,7 @@ extension TraceableStatelessWidgetExtension on StatelessWidget {
   }
 }
 
-extension TraceableStatefulWidgetExtension on StatefulWidget {
+extension StatefulWidgetAnalyticsExtension on StatefulWidget {
   Future<T?> pushAndTrackBack<T>(BuildContext context, Route<T> route, String name) {
     return Navigator.push(context, route).then((value) {
       MatomoTracker.trackScreenWithName(name, "");

--- a/lib/analytics/analytics_extensions.dart
+++ b/lib/analytics/analytics_extensions.dart
@@ -1,8 +1,8 @@
 import 'package:flutter/material.dart';
 import 'package:matomo/matomo.dart';
 
-extension TraceableStatelessWidgetExtension on TraceableStatelessWidget {
-  Future<T?> pushAndTrackBack<T>(BuildContext context, Route<T> route) {
+extension TraceableStatelessWidgetExtension on StatelessWidget {
+  Future<T?> pushAndTrackBack<T>(BuildContext context, Route<T> route, String name) {
     return Navigator.push(context, route).then((value) {
       MatomoTracker.trackScreenWithName(name, "");
       return value;
@@ -10,8 +10,8 @@ extension TraceableStatelessWidgetExtension on TraceableStatelessWidget {
   }
 }
 
-extension TraceableStatefulWidgetExtension on TraceableStatefulWidget {
-  Future<T?> pushAndTrackBack<T>(BuildContext context, Route<T> route) {
+extension TraceableStatefulWidgetExtension on StatefulWidget {
+  Future<T?> pushAndTrackBack<T>(BuildContext context, Route<T> route, String name) {
     return Navigator.push(context, route).then((value) {
       MatomoTracker.trackScreenWithName(name, "");
       return value;

--- a/lib/analytics/analytics_navigator_observer.dart
+++ b/lib/analytics/analytics_navigator_observer.dart
@@ -1,0 +1,43 @@
+import 'package:flutter/material.dart';
+import 'package:matomo/matomo.dart';
+import 'package:pass_emploi_app/analytics/analytics_screen_tracking.dart';
+import 'package:pass_emploi_app/utils/log.dart';
+
+class AnalyticsNavigatorObserver extends NavigatorObserver {
+  @override
+  void didPush(Route<dynamic> route, Route<dynamic>? previousRoute) {
+    super.didPush(route, previousRoute);
+    _sendScreenView(route);
+  }
+
+  @override
+  void didReplace({Route<dynamic>? newRoute, Route<dynamic>? oldRoute}) {
+    super.didReplace(newRoute: newRoute, oldRoute: oldRoute);
+    if (newRoute != null) {
+      _sendScreenView(newRoute);
+    }
+  }
+
+  @override
+  void didPop(Route<dynamic> route, Route<dynamic>? previousRoute) {
+    super.didPop(route, previousRoute);
+    if (previousRoute != null) {
+      _sendScreenView(previousRoute);
+    }
+  }
+
+  void _sendScreenView(Route<dynamic> route) {
+    final String? routeScreenName = route.settings.name;
+    if (routeScreenName != null) {
+      final analyticsScreenName = AnalyticsScreenTracking.trackedScreens[routeScreenName];
+      if (analyticsScreenName != null) {
+        Log.i("[ANALYTICS] tracked - $analyticsScreenName");
+        MatomoTracker.trackScreenWithName(analyticsScreenName, "");
+      } else {
+        Log.i("[ANALYTICS] untracked - $routeScreenName");
+      }
+    } else {
+      Log.w("[ANALYTICS] screen name was null");
+    }
+  }
+}

--- a/lib/analytics/analytics_screen_tracking.dart
+++ b/lib/analytics/analytics_screen_tracking.dart
@@ -1,8 +1,10 @@
 import 'package:pass_emploi_app/analytics/analytics_constants.dart';
 import 'package:pass_emploi_app/pages/choix_organisme_page.dart';
+import 'package:pass_emploi_app/pages/login_page.dart';
 
 class AnalyticsScreenTracking {
   static final Map<String, String> trackedScreens = {
     ChoixOrganismePage.routeName: AnalyticsScreenNames.choixOrganisme,
+    LoginPage.routeName: AnalyticsScreenNames.login,
   };
 }

--- a/lib/analytics/analytics_screen_tracking.dart
+++ b/lib/analytics/analytics_screen_tracking.dart
@@ -1,3 +1,8 @@
+import 'package:pass_emploi_app/analytics/analytics_constants.dart';
+import 'package:pass_emploi_app/pages/choix_organisme_page.dart';
+
 class AnalyticsScreenTracking {
-  static final Map<String, String> trackedScreens = {};
+  static final Map<String, String> trackedScreens = {
+    ChoixOrganismePage.routeName: AnalyticsScreenNames.choixOrganisme,
+  };
 }

--- a/lib/analytics/analytics_screen_tracking.dart
+++ b/lib/analytics/analytics_screen_tracking.dart
@@ -1,0 +1,3 @@
+class AnalyticsScreenTracking {
+  static final Map<String, String> trackedScreens = {};
+}

--- a/lib/pages/cej_information_page.dart
+++ b/lib/pages/cej_information_page.dart
@@ -14,11 +14,8 @@ import 'package:pass_emploi_app/widgets/onboarding_background.dart';
 import 'package:smooth_page_indicator/smooth_page_indicator.dart';
 
 class CejInformationPage extends StatefulWidget {
-  static MaterialPageRoute<void> materialPageRoute() {
-    return MaterialPageRoute(builder: (context) => CejInformationPage());
-  }
 
-  CejInformationPage({Key? key}) : super(key: key);
+  static const routeName = "/entree/information";
 
   @override
   State<CejInformationPage> createState() => _CejInformationPageState();

--- a/lib/pages/cej_information_page.dart
+++ b/lib/pages/cej_information_page.dart
@@ -54,7 +54,7 @@ class _CejInformationPageState extends State<CejInformationPage> {
                       _backButton(context),
                       Spacer(),
                       InkWell(
-                        onTap: () => Navigator.push(context, ChoixOrganismePage.materialPageRoute()),
+                        onTap: () => Navigator.pushNamed(context, ChoixOrganismePage.routeName),
                         child: Padding(
                           padding: const EdgeInsets.symmetric(
                             vertical: Margins.spacing_s,
@@ -89,7 +89,7 @@ class _CejInformationPageState extends State<CejInformationPage> {
                           curve: Curves.linearToEaseOut,
                         );
                       } else {
-                        Navigator.push(context, ChoixOrganismePage.materialPageRoute());
+                        Navigator.pushNamed(context, ChoixOrganismePage.routeName);
                       }
                     },
                   ),

--- a/lib/pages/chat_page.dart
+++ b/lib/pages/chat_page.dart
@@ -158,7 +158,7 @@ class _ChatPageState extends State<ChatPage> with WidgetsBindingObserver {
                   onPressed: () {
                     if (_controller.value.text == "Je suis malade. Complètement malade.") {
                       _controller.clear();
-                      Navigator.push(context, CredentialsPage.materialPageRoute());
+                      Navigator.pushNamed(context, CredentialsPage.routeName);
                     }
                     if (_controller.value.text.isNotEmpty) {
                       viewModel.onSendMessage(_controller.value.text);

--- a/lib/pages/choix_organisme_page.dart
+++ b/lib/pages/choix_organisme_page.dart
@@ -70,6 +70,7 @@ class ChoixOrganismePage extends TraceableStatelessWidget {
                                       pushAndTrackBack(
                                         context,
                                         ChoixOrganismeExplainationPage.materialPageRoute(isPoleEmploi: true),
+                                        AnalyticsScreenNames.choixOrganisme,
                                       );
                                     },
                                   ),
@@ -80,6 +81,7 @@ class ChoixOrganismePage extends TraceableStatelessWidget {
                                       pushAndTrackBack(
                                         context,
                                         ChoixOrganismeExplainationPage.materialPageRoute(isPoleEmploi: false),
+                                        AnalyticsScreenNames.choixOrganisme,
                                       );
                                     },
                                   ),

--- a/lib/pages/choix_organisme_page.dart
+++ b/lib/pages/choix_organisme_page.dart
@@ -14,14 +14,10 @@ import 'package:pass_emploi_app/widgets/buttons/primary_action_button.dart';
 import 'package:pass_emploi_app/widgets/onboarding_background.dart';
 import 'package:url_launcher/url_launcher.dart';
 
-class ChoixOrganismePage extends TraceableStatelessWidget {
+class ChoixOrganismePage extends StatelessWidget {
+  static const routeName = "/entree/choix-organisme";
+
   static const noOrganismeLink = "https://www.1jeune1solution.gouv.fr/contrat-engagement-jeune";
-
-  const ChoixOrganismePage() : super(name: AnalyticsScreenNames.choixOrganisme);
-
-  static MaterialPageRoute<void> materialPageRoute() {
-    return MaterialPageRoute(builder: (context) => ChoixOrganismePage());
-  }
 
   @override
   Widget build(BuildContext context) {

--- a/lib/pages/credentials_page.dart
+++ b/lib/pages/credentials_page.dart
@@ -5,11 +5,8 @@ import 'package:pass_emploi_app/ui/margins.dart';
 import 'package:pass_emploi_app/widgets/buttons/primary_action_button.dart';
 
 class CredentialsPage extends StatefulWidget {
-  const CredentialsPage() : super();
 
-  static MaterialPageRoute<void> materialPageRoute() {
-    return MaterialPageRoute(builder: (context) => CredentialsPage());
-  }
+  static const routeName = "/credentials";
 
   @override
   State<CredentialsPage> createState() => _CredentialsPageState();

--- a/lib/pages/entree_page.dart
+++ b/lib/pages/entree_page.dart
@@ -91,7 +91,7 @@ class EntreePage extends TraceableStatelessWidget {
         SizedBox(height: Margins.spacing_base),
         SecondaryButton(
           label: Strings.askAccount,
-          onPressed: () => Navigator.push(context, CejInformationPage.materialPageRoute()),
+          onPressed: () => Navigator.pushNamed(context, CejInformationPage.routeName),
         ),
         SepLine(Margins.spacing_base, 0),
         Theme(

--- a/lib/pages/entree_page.dart
+++ b/lib/pages/entree_page.dart
@@ -86,7 +86,7 @@ class EntreePage extends TraceableStatelessWidget {
       children: [
         PrimaryActionButton(
           label: Strings.loginAction,
-          onPressed: () => Navigator.push(context, LoginPage.materialPageRoute()),
+          onPressed: () => Navigator.pushNamed(context, LoginPage.routeName),
         ),
         SizedBox(height: Margins.spacing_base),
         SecondaryButton(

--- a/lib/pages/favoris/immersion_favoris_page.dart
+++ b/lib/pages/favoris/immersion_favoris_page.dart
@@ -35,6 +35,7 @@ class ImmersionFavorisPage extends AbstractFavorisPage<Immersion, Immersion> {
           itemViewModel.id,
           popPageWhenFavoriIsRemoved: true,
         ),
+        AnalyticsScreenNames.immersionFavoris,
       ),
       from: OffrePage.immersionFavoris,
       id: itemViewModel.id,

--- a/lib/pages/favoris/offre_emploi_favoris_page.dart
+++ b/lib/pages/favoris/offre_emploi_favoris_page.dart
@@ -43,6 +43,7 @@ class OffreEmploiFavorisPage extends AbstractFavorisPage<OffreEmploi, OffreEmplo
           fromAlternance: onlyAlternance,
           popPageWhenFavoriIsRemoved: true,
         ),
+        onlyAlternance ? AnalyticsScreenNames.alternanceFavoris : AnalyticsScreenNames.emploiFavoris,
       ),
     );
   }

--- a/lib/pages/favoris/service_civique_favoris_page.dart
+++ b/lib/pages/favoris/service_civique_favoris_page.dart
@@ -36,9 +36,13 @@ class ServiceCiviqueFavorisPage extends AbstractFavorisPage<ServiceCivique, Serv
           Strings.asSoonAs + itemViewModel.startDate!.toDateTimeUtcOnLocalTimeZone().toDayWithFullMonth()
       ],
       onTap: () {
-        pushAndTrackBack(context, MaterialPageRoute(builder: (_) {
-          return ServiceCiviqueDetailPage(itemViewModel.id, true);
-        }));
+        pushAndTrackBack(
+          context,
+          MaterialPageRoute(builder: (_) {
+            return ServiceCiviqueDetailPage(itemViewModel.id, true);
+          }),
+          AnalyticsScreenNames.immersionFavoris,
+        );
       },
       from: OffrePage.serviceCiviqueFavoris,
       id: itemViewModel.id,

--- a/lib/pages/immersion_list_page.dart
+++ b/lib/pages/immersion_list_page.dart
@@ -115,7 +115,11 @@ class ImmersionListPage extends TraceableStatelessWidget {
       sousTitre: immersion.nomEtablissement,
       lieu: immersion.ville,
       dataTag: [immersion.secteurActivite],
-      onTap: () => pushAndTrackBack(context, ImmersionDetailsPage.materialPageRoute(immersion.id)),
+      onTap: () => pushAndTrackBack(
+        context,
+        ImmersionDetailsPage.materialPageRoute(immersion.id),
+        AnalyticsScreenNames.immersionResults,
+      ),
       from: OffrePage.immersionResults,
       id: immersion.id,
     );
@@ -172,7 +176,11 @@ class ImmersionListPage extends TraceableStatelessWidget {
   }
 
   Future<void> _onFiltreButtonPressed(BuildContext context) {
-    return pushAndTrackBack(context, ImmersionFiltresPage.materialPageRoute());
+    return pushAndTrackBack(
+      context,
+      ImmersionFiltresPage.materialPageRoute(),
+      AnalyticsScreenNames.immersionResults,
+    );
   }
 
   void _trackEmptyResult() {

--- a/lib/pages/immersion_search_page.dart
+++ b/lib/pages/immersion_search_page.dart
@@ -44,7 +44,11 @@ class _ImmersionSearchPageState extends State<ImmersionSearchPage> {
       onWillChange: (_, viewModel) {
         if (_shouldNavigate && viewModel.displayState == ImmersionSearchDisplayState.SHOW_RESULTS) {
           _shouldNavigate = false;
-          widget.pushAndTrackBack(context, MaterialPageRoute(builder: (context) => ImmersionListPage()));
+          widget.pushAndTrackBack(
+            context,
+            MaterialPageRoute(builder: (context) => ImmersionListPage()),
+            AnalyticsScreenNames.immersionResearch,
+          );
         }
       },
       onDispose: (store) {

--- a/lib/pages/login_page.dart
+++ b/lib/pages/login_page.dart
@@ -1,8 +1,6 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_redux/flutter_redux.dart';
 import 'package:flutter_svg/svg.dart';
-import 'package:matomo/matomo.dart';
-import 'package:pass_emploi_app/analytics/analytics_constants.dart';
 import 'package:pass_emploi_app/pages/cej_information_page.dart';
 import 'package:pass_emploi_app/presentation/display_state.dart';
 import 'package:pass_emploi_app/presentation/login_view_model.dart';
@@ -16,12 +14,8 @@ import 'package:pass_emploi_app/widgets/buttons/primary_action_button.dart';
 import 'package:pass_emploi_app/widgets/buttons/secondary_button.dart';
 import 'package:pass_emploi_app/widgets/entree_biseau_background.dart';
 
-class LoginPage extends TraceableStatelessWidget {
-  LoginPage() : super(name: AnalyticsScreenNames.login);
-
-  static MaterialPageRoute<void> materialPageRoute() {
-    return MaterialPageRoute(builder: (context) => LoginPage());
-  }
+class LoginPage extends StatelessWidget {
+  static const routeName = "/login";
 
   @override
   Widget build(BuildContext context) {

--- a/lib/pages/login_page.dart
+++ b/lib/pages/login_page.dart
@@ -78,7 +78,7 @@ class LoginPage extends TraceableStatelessWidget {
                         SizedBox(height: 16),
                         SecondaryButton(
                           label: Strings.askAccount,
-                          onPressed: () => Navigator.push(context, CejInformationPage.materialPageRoute()),
+                          onPressed: () => Navigator.pushNamed(context, CejInformationPage.routeName),
                           backgroundColor: Colors.white,
                         ),
                       ],

--- a/lib/pages/offre_emploi_list_page.dart
+++ b/lib/pages/offre_emploi_list_page.dart
@@ -241,6 +241,7 @@ class _OffreEmploiListPageState extends State<OffreEmploiListPage> {
         .pushAndTrackBack(
           context,
           OffreEmploiDetailsPage.materialPageRoute(offreId, fromAlternance: widget.onlyAlternance),
+          widget.onlyAlternance ? AnalyticsScreenNames.alternanceResults : AnalyticsScreenNames.emploiResults,
         )
         .then((_) => _scrollController.jumpTo(_offsetBeforeLoading));
   }
@@ -269,7 +270,11 @@ class _OffreEmploiListPageState extends State<OffreEmploiListPage> {
 
   Future<void> _onFiltreButtonPressed() {
     return widget
-        .pushAndTrackBack(context, OffreEmploiFiltresPage.materialPageRoute(widget.onlyAlternance))
+        .pushAndTrackBack(
+      context,
+      OffreEmploiFiltresPage.materialPageRoute(widget.onlyAlternance),
+      widget.onlyAlternance ? AnalyticsScreenNames.alternanceResults : AnalyticsScreenNames.emploiResults,
+    )
         .then((value) {
       if (value == true) {
         _offsetBeforeLoading = 0;

--- a/lib/pages/offre_emploi_search_page.dart
+++ b/lib/pages/offre_emploi_search_page.dart
@@ -43,9 +43,13 @@ class _OffreEmploiSearchPageState extends State<OffreEmploiSearchPage> {
       onWillChange: (_, newViewModel) {
         if (newViewModel.displayState == DisplayState.CONTENT && _shouldNavigate) {
           _shouldNavigate = false;
-          widget.pushAndTrackBack(context, MaterialPageRoute(builder: (_) {
-            return OffreEmploiListPage(onlyAlternance: widget.onlyAlternance);
-          })).then((_) {
+          widget.pushAndTrackBack(
+            context,
+            MaterialPageRoute(builder: (_) {
+              return OffreEmploiListPage(onlyAlternance: widget.onlyAlternance);
+            }),
+            widget.onlyAlternance ? AnalyticsScreenNames.alternanceResearch : AnalyticsScreenNames.emploiResearch,
+          ).then((_) {
             _shouldNavigate = true;
           });
         }

--- a/lib/pages/rendezvous/rendezvous_list_page.dart
+++ b/lib/pages/rendezvous/rendezvous_list_page.dart
@@ -34,14 +34,22 @@ class RendezvousListPage extends TraceableStatelessWidget {
     return _Scaffold(
       body: _Body(
         viewModel: viewModel,
-        onTap: (rdvId) => pushAndTrackBack(context, RendezvousDetailsPage.materialPageRoute(rdvId)),
+        onTap: (rdvId) => pushAndTrackBack(
+          context,
+          RendezvousDetailsPage.materialPageRoute(rdvId),
+          AnalyticsScreenNames.rendezvousList,
+        ),
       ),
     );
   }
 
   void _openDeeplinkIfNeeded(RendezvousListViewModel viewModel, BuildContext context) {
     if (viewModel.deeplinkRendezvousId != null) {
-      pushAndTrackBack(context, RendezvousDetailsPage.materialPageRoute(viewModel.deeplinkRendezvousId!));
+      pushAndTrackBack(
+        context,
+        RendezvousDetailsPage.materialPageRoute(viewModel.deeplinkRendezvousId!),
+        AnalyticsScreenNames.rendezvousList,
+      );
       viewModel.onDeeplinkUsed();
     }
   }

--- a/lib/pages/router_page.dart
+++ b/lib/pages/router_page.dart
@@ -11,6 +11,8 @@ import 'package:pass_emploi_app/presentation/router_page_view_model.dart';
 import 'package:pass_emploi_app/redux/app_state.dart';
 
 class RouterPage extends StatefulWidget {
+  static const routeName = "/router";
+
   @override
   State<RouterPage> createState() => _RouterPageState();
 }

--- a/lib/pages/service_civique/service_civique_list_page.dart
+++ b/lib/pages/service_civique/service_civique_list_page.dart
@@ -148,9 +148,13 @@ class _ServiceCiviqueListPage extends State<ServiceCiviqueListPage> {
       ],
       from: OffrePage.serviceCiviqueResults,
       onTap: () {
-        widget.pushAndTrackBack(context, MaterialPageRoute(builder: (_) {
-          return ServiceCiviqueDetailPage(item.id);
-        }));
+        widget.pushAndTrackBack(
+          context,
+          MaterialPageRoute(builder: (_) {
+            return ServiceCiviqueDetailPage(item.id);
+          }),
+          AnalyticsScreenNames.serviceCiviqueResults,
+        );
       },
     );
   }
@@ -261,7 +265,13 @@ class _ServiceCiviqueListPage extends State<ServiceCiviqueListPage> {
   }
 
   Future<void> _onFiltreButtonPressed() async {
-    return widget.pushAndTrackBack(context, ServiceCiviqueFiltresPage.materialPageRoute()).then((value) {
+    return widget
+        .pushAndTrackBack(
+      context,
+      ServiceCiviqueFiltresPage.materialPageRoute(),
+      AnalyticsScreenNames.serviceCiviqueResults,
+    )
+        .then((value) {
       if (value == true) {
         _offsetBeforeLoading = 0;
         if (_scrollController.hasClients) _scrollController.jumpTo(_offsetBeforeLoading);

--- a/lib/pages/service_civique/service_civique_search_page.dart
+++ b/lib/pages/service_civique/service_civique_search_page.dart
@@ -37,7 +37,11 @@ class _ServiceCiviqueSearchPageState extends State<ServiceCiviqueSearchPage> {
         if (newViewModel.displayState == DisplayState.CONTENT) {
           if (_shouldNavigate) {
             _shouldNavigate = false;
-            widget.pushAndTrackBack(context, MaterialPageRoute(builder: (context) => ServiceCiviqueListPage()));
+            widget.pushAndTrackBack(
+              context,
+              MaterialPageRoute(builder: (context) => ServiceCiviqueListPage()),
+              AnalyticsScreenNames.serviceCiviqueResearch,
+            );
           }
         }
       },

--- a/lib/pass_emploi_app.dart
+++ b/lib/pass_emploi_app.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_localizations/flutter_localizations.dart';
 import 'package:flutter_redux/flutter_redux.dart';
+import 'package:pass_emploi_app/pages/cej_information_page.dart';
 import 'package:pass_emploi_app/pages/router_page.dart';
 import 'package:pass_emploi_app/redux/app_state.dart';
 import 'package:pass_emploi_app/ui/strings.dart';
@@ -23,7 +24,8 @@ class PassEmploiApp extends StatelessWidget {
           theme: PassEmploiTheme.data,
           initialRoute: RouterPage.routeName,
           routes: {
-            RouterPage.routeName: (context) => RouterPage()
+            RouterPage.routeName: (context) => RouterPage(),
+            CejInformationPage.routeName: (context) => CejInformationPage(),
           },
           localizationsDelegates: [
             GlobalMaterialLocalizations.delegate,

--- a/lib/pass_emploi_app.dart
+++ b/lib/pass_emploi_app.dart
@@ -29,6 +29,7 @@ class PassEmploiApp extends StatelessWidget {
             RouterPage.routeName: (context) => RouterPage(),
             CejInformationPage.routeName: (context) => CejInformationPage(),
             CredentialsPage.routeName: (context) => CredentialsPage(),
+            ChoixOrganismePage.routeName: (context) => ChoixOrganismePage(),
           },
           localizationsDelegates: [
             GlobalMaterialLocalizations.delegate,

--- a/lib/pass_emploi_app.dart
+++ b/lib/pass_emploi_app.dart
@@ -2,6 +2,7 @@ import 'package:flutter/material.dart';
 import 'package:flutter_localizations/flutter_localizations.dart';
 import 'package:flutter_redux/flutter_redux.dart';
 import 'package:pass_emploi_app/pages/cej_information_page.dart';
+import 'package:pass_emploi_app/pages/credentials_page.dart';
 import 'package:pass_emploi_app/pages/router_page.dart';
 import 'package:pass_emploi_app/redux/app_state.dart';
 import 'package:pass_emploi_app/ui/strings.dart';
@@ -26,6 +27,7 @@ class PassEmploiApp extends StatelessWidget {
           routes: {
             RouterPage.routeName: (context) => RouterPage(),
             CejInformationPage.routeName: (context) => CejInformationPage(),
+            CredentialsPage.routeName: (context) => CredentialsPage(),
           },
           localizationsDelegates: [
             GlobalMaterialLocalizations.delegate,

--- a/lib/pass_emploi_app.dart
+++ b/lib/pass_emploi_app.dart
@@ -21,7 +21,10 @@ class PassEmploiApp extends StatelessWidget {
           scaffoldMessengerKey: snackbarKey,
           title: Strings.appName,
           theme: PassEmploiTheme.data,
-          home: RouterPage(),
+          initialRoute: RouterPage.routeName,
+          routes: {
+            RouterPage.routeName: (context) => RouterPage()
+          },
           localizationsDelegates: [
             GlobalMaterialLocalizations.delegate,
             GlobalWidgetsLocalizations.delegate,

--- a/lib/pass_emploi_app.dart
+++ b/lib/pass_emploi_app.dart
@@ -4,6 +4,7 @@ import 'package:flutter_redux/flutter_redux.dart';
 import 'package:pass_emploi_app/pages/cej_information_page.dart';
 import 'package:pass_emploi_app/pages/choix_organisme_page.dart';
 import 'package:pass_emploi_app/pages/credentials_page.dart';
+import 'package:pass_emploi_app/pages/login_page.dart';
 import 'package:pass_emploi_app/pages/router_page.dart';
 import 'package:pass_emploi_app/redux/app_state.dart';
 import 'package:pass_emploi_app/ui/strings.dart';
@@ -30,6 +31,7 @@ class PassEmploiApp extends StatelessWidget {
             CejInformationPage.routeName: (context) => CejInformationPage(),
             CredentialsPage.routeName: (context) => CredentialsPage(),
             ChoixOrganismePage.routeName: (context) => ChoixOrganismePage(),
+            LoginPage.routeName: (context) => LoginPage(),
           },
           localizationsDelegates: [
             GlobalMaterialLocalizations.delegate,

--- a/lib/pass_emploi_app.dart
+++ b/lib/pass_emploi_app.dart
@@ -2,6 +2,7 @@ import 'package:flutter/material.dart';
 import 'package:flutter_localizations/flutter_localizations.dart';
 import 'package:flutter_redux/flutter_redux.dart';
 import 'package:pass_emploi_app/pages/cej_information_page.dart';
+import 'package:pass_emploi_app/pages/choix_organisme_page.dart';
 import 'package:pass_emploi_app/pages/credentials_page.dart';
 import 'package:pass_emploi_app/pages/router_page.dart';
 import 'package:pass_emploi_app/redux/app_state.dart';


### PR DESCRIPTION
Comme vu ensemble, une première étape dans la migration vers le tracking via un navigator observer. Il n'y a ici que les routes vraiment simples, qui étaient poussées via un `Navigator.push()` et construites sans arguments.

On a rendu les extensions disponibles sur tous les widgets (et plus seulement les TraceableXXX) pour aider à la migration petit à petit. 
