### PR TITLE
[TECH] use navigator observer for complex route

### DIFF
--- a/lib/analytics/analytics_constants.dart
+++ b/lib/analytics/analytics_constants.dart
@@ -10,7 +10,6 @@ class AnalyticsScreenNames {
 
   static String cejInformationPage(int pageNumber) => "entree/etape-$pageNumber";
 
-  static const login = "login";
   static const userActionList = "actions/list";
   static const userActionDetails = "actions/detail";
   static const updateUserAction = "actions/detail?modifySuccess=true";

--- a/lib/analytics/analytics_extensions.dart
+++ b/lib/analytics/analytics_extensions.dart
@@ -1,7 +1,7 @@
 import 'package:flutter/material.dart';
 import 'package:matomo/matomo.dart';
 
-extension TraceableStatelessWidgetExtension on StatelessWidget {
+extension StatelessWidgetAnalyticsExtension on StatelessWidget {
   Future<T?> pushAndTrackBack<T>(BuildContext context, Route<T> route, String name) {
     return Navigator.push(context, route).then((value) {
       MatomoTracker.trackScreenWithName(name, "");
@@ -10,7 +10,7 @@ extension TraceableStatelessWidgetExtension on StatelessWidget {
   }
 }
 
-extension TraceableStatefulWidgetExtension on StatefulWidget {
+extension StatefulWidgetAnalyticsExtension on StatefulWidget {
   Future<T?> pushAndTrackBack<T>(BuildContext context, Route<T> route, String name) {
     return Navigator.push(context, route).then((value) {
       MatomoTracker.trackScreenWithName(name, "");

--- a/lib/analytics/analytics_extensions.dart
+++ b/lib/analytics/analytics_extensions.dart
@@ -1,8 +1,8 @@
 import 'package:flutter/material.dart';
 import 'package:matomo/matomo.dart';
 
-extension TraceableStatelessWidgetExtension on TraceableStatelessWidget {
-  Future<T?> pushAndTrackBack<T>(BuildContext context, Route<T> route) {
+extension TraceableStatelessWidgetExtension on StatelessWidget {
+  Future<T?> pushAndTrackBack<T>(BuildContext context, Route<T> route, String name) {
     return Navigator.push(context, route).then((value) {
       MatomoTracker.trackScreenWithName(name, "");
       return value;
@@ -10,8 +10,8 @@ extension TraceableStatelessWidgetExtension on TraceableStatelessWidget {
   }
 }
 
-extension TraceableStatefulWidgetExtension on TraceableStatefulWidget {
-  Future<T?> pushAndTrackBack<T>(BuildContext context, Route<T> route) {
+extension TraceableStatefulWidgetExtension on StatefulWidget {
+  Future<T?> pushAndTrackBack<T>(BuildContext context, Route<T> route, String name) {
     return Navigator.push(context, route).then((value) {
       MatomoTracker.trackScreenWithName(name, "");
       return value;

--- a/lib/analytics/analytics_navigator_observer.dart
+++ b/lib/analytics/analytics_navigator_observer.dart
@@ -29,8 +29,9 @@ class AnalyticsNavigatorObserver extends NavigatorObserver {
   void _sendScreenView(Route<dynamic> route) {
     final String? routeScreenName = route.settings.name;
     if (routeScreenName != null) {
-      final analyticsScreenName = AnalyticsScreenTracking.trackedScreens[routeScreenName];
-      if (analyticsScreenName != null) {
+      final analyticsNameGenerator = AnalyticsScreenTracking.trackedScreens[routeScreenName];
+      if (analyticsNameGenerator != null) {
+        final analyticsScreenName = analyticsNameGenerator(route.settings);
         Log.i("[ANALYTICS] tracked - $analyticsScreenName");
         MatomoTracker.trackScreenWithName(analyticsScreenName, "");
       } else {

--- a/lib/analytics/analytics_navigator_observer.dart
+++ b/lib/analytics/analytics_navigator_observer.dart
@@ -29,9 +29,8 @@ class AnalyticsNavigatorObserver extends NavigatorObserver {
   void _sendScreenView(Route<dynamic> route) {
     final String? routeScreenName = route.settings.name;
     if (routeScreenName != null) {
-      final analyticsNameGenerator = AnalyticsScreenTracking.trackedScreens[routeScreenName];
-      if (analyticsNameGenerator != null) {
-        final analyticsScreenName = analyticsNameGenerator(route.settings);
+      final analyticsScreenName = AnalyticsScreenTracking.onGenerateScreenTracking(route.settings);
+      if (analyticsScreenName != null) {
         Log.i("[ANALYTICS] tracked - $analyticsScreenName");
         MatomoTracker.trackScreenWithName(analyticsScreenName, "");
       } else {

--- a/lib/analytics/analytics_navigator_observer.dart
+++ b/lib/analytics/analytics_navigator_observer.dart
@@ -1,0 +1,43 @@
+import 'package:flutter/material.dart';
+import 'package:matomo/matomo.dart';
+import 'package:pass_emploi_app/analytics/analytics_screen_tracking.dart';
+import 'package:pass_emploi_app/utils/log.dart';
+
+class AnalyticsNavigatorObserver extends NavigatorObserver {
+  @override
+  void didPush(Route<dynamic> route, Route<dynamic>? previousRoute) {
+    super.didPush(route, previousRoute);
+    _sendScreenView(route);
+  }
+
+  @override
+  void didReplace({Route<dynamic>? newRoute, Route<dynamic>? oldRoute}) {
+    super.didReplace(newRoute: newRoute, oldRoute: oldRoute);
+    if (newRoute != null) {
+      _sendScreenView(newRoute);
+    }
+  }
+
+  @override
+  void didPop(Route<dynamic> route, Route<dynamic>? previousRoute) {
+    super.didPop(route, previousRoute);
+    if (previousRoute != null) {
+      _sendScreenView(previousRoute);
+    }
+  }
+
+  void _sendScreenView(Route<dynamic> route) {
+    final String? routeScreenName = route.settings.name;
+    if (routeScreenName != null) {
+      final analyticsScreenName = AnalyticsScreenTracking.trackedScreens[routeScreenName];
+      if (analyticsScreenName != null) {
+        Log.i("[ANALYTICS] tracked - $analyticsScreenName");
+        MatomoTracker.trackScreenWithName(analyticsScreenName, "");
+      } else {
+        Log.i("[ANALYTICS] untracked - $routeScreenName");
+      }
+    } else {
+      Log.w("[ANALYTICS] screen name was null");
+    }
+  }
+}

--- a/lib/analytics/analytics_screen_tracking.dart
+++ b/lib/analytics/analytics_screen_tracking.dart
@@ -1,8 +1,10 @@
 import 'package:pass_emploi_app/analytics/analytics_constants.dart';
 import 'package:pass_emploi_app/pages/choix_organisme_page.dart';
+import 'package:pass_emploi_app/pages/login_page.dart';
 
 class AnalyticsScreenTracking {
   static final Map<String, String> trackedScreens = {
     ChoixOrganismePage.routeName: AnalyticsScreenNames.choixOrganisme,
+    LoginPage.routeName: AnalyticsScreenNames.login,
   };
 }

--- a/lib/analytics/analytics_screen_tracking.dart
+++ b/lib/analytics/analytics_screen_tracking.dart
@@ -8,7 +8,7 @@ class AnalyticsScreenTracking {
   static String? onGenerateScreenTracking(RouteSettings settings) {
     final routeName = settings.name;
     if (routeName == ChoixOrganismePage.routeName) return AnalyticsScreenNames.choixOrganisme;
-    if (routeName == LoginPage.routeName) return AnalyticsScreenNames.login;
+    if (routeName == LoginPage.routeName) return "login";
     if (routeName == OffreEmploiListPage.routeName) {
       final args = settings.arguments as Map<String, dynamic>;
       return args["onlyAlternance"] as bool

--- a/lib/analytics/analytics_screen_tracking.dart
+++ b/lib/analytics/analytics_screen_tracking.dart
@@ -1,3 +1,8 @@
+import 'package:pass_emploi_app/analytics/analytics_constants.dart';
+import 'package:pass_emploi_app/pages/choix_organisme_page.dart';
+
 class AnalyticsScreenTracking {
-  static final Map<String, String> trackedScreens = {};
+  static final Map<String, String> trackedScreens = {
+    ChoixOrganismePage.routeName: AnalyticsScreenNames.choixOrganisme,
+  };
 }

--- a/lib/analytics/analytics_screen_tracking.dart
+++ b/lib/analytics/analytics_screen_tracking.dart
@@ -1,10 +1,18 @@
+import 'package:flutter/cupertino.dart';
 import 'package:pass_emploi_app/analytics/analytics_constants.dart';
 import 'package:pass_emploi_app/pages/choix_organisme_page.dart';
 import 'package:pass_emploi_app/pages/login_page.dart';
+import 'package:pass_emploi_app/pages/offre_emploi_list_page.dart';
 
 class AnalyticsScreenTracking {
-  static final Map<String, String> trackedScreens = {
-    ChoixOrganismePage.routeName: AnalyticsScreenNames.choixOrganisme,
-    LoginPage.routeName: AnalyticsScreenNames.login,
+  static final Map<String, String Function(RouteSettings settings)> trackedScreens = {
+    ChoixOrganismePage.routeName: (settings) => AnalyticsScreenNames.choixOrganisme,
+    LoginPage.routeName: (settings) => AnalyticsScreenNames.login,
+    OffreEmploiListPage.routeName: (settings) {
+      final args = settings.arguments as Map<String, dynamic>;
+      return args["onlyAlternance"] as bool
+          ? AnalyticsScreenNames.alternanceResults
+          : AnalyticsScreenNames.emploiResults;
+    }
   };
 }

--- a/lib/analytics/analytics_screen_tracking.dart
+++ b/lib/analytics/analytics_screen_tracking.dart
@@ -1,0 +1,3 @@
+class AnalyticsScreenTracking {
+  static final Map<String, String> trackedScreens = {};
+}

--- a/lib/analytics/analytics_screen_tracking.dart
+++ b/lib/analytics/analytics_screen_tracking.dart
@@ -5,14 +5,16 @@ import 'package:pass_emploi_app/pages/login_page.dart';
 import 'package:pass_emploi_app/pages/offre_emploi_list_page.dart';
 
 class AnalyticsScreenTracking {
-  static final Map<String, String Function(RouteSettings settings)> trackedScreens = {
-    ChoixOrganismePage.routeName: (settings) => AnalyticsScreenNames.choixOrganisme,
-    LoginPage.routeName: (settings) => AnalyticsScreenNames.login,
-    OffreEmploiListPage.routeName: (settings) {
+  static String? onGenerateScreenTracking(RouteSettings settings) {
+    final routeName = settings.name;
+    if (routeName == ChoixOrganismePage.routeName) return AnalyticsScreenNames.choixOrganisme;
+    if (routeName == LoginPage.routeName) return AnalyticsScreenNames.login;
+    if (routeName == OffreEmploiListPage.routeName) {
       final args = settings.arguments as Map<String, dynamic>;
       return args["onlyAlternance"] as bool
           ? AnalyticsScreenNames.alternanceResults
           : AnalyticsScreenNames.emploiResults;
     }
-  };
+    return null;
+  }
 }

--- a/lib/app_router.dart
+++ b/lib/app_router.dart
@@ -1,0 +1,35 @@
+import 'package:flutter/material.dart';
+import 'package:pass_emploi_app/pages/cej_information_page.dart';
+import 'package:pass_emploi_app/pages/choix_organisme_page.dart';
+import 'package:pass_emploi_app/pages/credentials_page.dart';
+import 'package:pass_emploi_app/pages/login_page.dart';
+import 'package:pass_emploi_app/pages/offre_emploi_list_page.dart';
+import 'package:pass_emploi_app/pages/router_page.dart';
+
+class AppRouter {
+  MaterialPageRoute<dynamic>? getMaterialPageRoute(RouteSettings settings) {
+    switch (settings.name) {
+      case RouterPage.routeName:
+        return MaterialPageRoute(builder: (context) => RouterPage());
+      case CejInformationPage.routeName:
+        return MaterialPageRoute(builder: (context) => CejInformationPage());
+      case CredentialsPage.routeName:
+        return MaterialPageRoute(builder: (context) => CredentialsPage());
+      case ChoixOrganismePage.routeName:
+        return MaterialPageRoute(builder: (context) => ChoixOrganismePage());
+      case LoginPage.routeName:
+        return MaterialPageRoute(builder: (context) => LoginPage());
+      case OffreEmploiListPage.routeName:
+        final args = settings.arguments as Map<String, dynamic>;
+        return MaterialPageRoute(
+          builder: (context) => OffreEmploiListPage(
+            onlyAlternance: args["onlyAlternance"] as bool,
+            fromSavedSearch: (args["fromSavedSearch"] ?? false) as bool,
+          ),
+          settings: settings,
+        );
+      default:
+        return null;
+    }
+  }
+}

--- a/lib/pages/cej_information_page.dart
+++ b/lib/pages/cej_information_page.dart
@@ -14,11 +14,8 @@ import 'package:pass_emploi_app/widgets/onboarding_background.dart';
 import 'package:smooth_page_indicator/smooth_page_indicator.dart';
 
 class CejInformationPage extends StatefulWidget {
-  static MaterialPageRoute<void> materialPageRoute() {
-    return MaterialPageRoute(builder: (context) => CejInformationPage());
-  }
 
-  CejInformationPage({Key? key}) : super(key: key);
+  static const routeName = "/entree/information";
 
   @override
   State<CejInformationPage> createState() => _CejInformationPageState();

--- a/lib/pages/cej_information_page.dart
+++ b/lib/pages/cej_information_page.dart
@@ -54,7 +54,7 @@ class _CejInformationPageState extends State<CejInformationPage> {
                       _backButton(context),
                       Spacer(),
                       InkWell(
-                        onTap: () => Navigator.push(context, ChoixOrganismePage.materialPageRoute()),
+                        onTap: () => Navigator.pushNamed(context, ChoixOrganismePage.routeName),
                         child: Padding(
                           padding: const EdgeInsets.symmetric(
                             vertical: Margins.spacing_s,
@@ -89,7 +89,7 @@ class _CejInformationPageState extends State<CejInformationPage> {
                           curve: Curves.linearToEaseOut,
                         );
                       } else {
-                        Navigator.push(context, ChoixOrganismePage.materialPageRoute());
+                        Navigator.pushNamed(context, ChoixOrganismePage.routeName);
                       }
                     },
                   ),

--- a/lib/pages/cej_information_page.dart
+++ b/lib/pages/cej_information_page.dart
@@ -14,7 +14,6 @@ import 'package:pass_emploi_app/widgets/onboarding_background.dart';
 import 'package:smooth_page_indicator/smooth_page_indicator.dart';
 
 class CejInformationPage extends StatefulWidget {
-
   static const routeName = "/entree/information";
 
   @override

--- a/lib/pages/chat_page.dart
+++ b/lib/pages/chat_page.dart
@@ -158,7 +158,7 @@ class _ChatPageState extends State<ChatPage> with WidgetsBindingObserver {
                   onPressed: () {
                     if (_controller.value.text == "Je suis malade. Complètement malade.") {
                       _controller.clear();
-                      Navigator.push(context, CredentialsPage.materialPageRoute());
+                      Navigator.pushNamed(context, CredentialsPage.routeName);
                     }
                     if (_controller.value.text.isNotEmpty) {
                       viewModel.onSendMessage(_controller.value.text);

--- a/lib/pages/choix_organisme_page.dart
+++ b/lib/pages/choix_organisme_page.dart
@@ -70,6 +70,7 @@ class ChoixOrganismePage extends TraceableStatelessWidget {
                                       pushAndTrackBack(
                                         context,
                                         ChoixOrganismeExplainationPage.materialPageRoute(isPoleEmploi: true),
+                                        AnalyticsScreenNames.choixOrganisme,
                                       );
                                     },
                                   ),
@@ -80,6 +81,7 @@ class ChoixOrganismePage extends TraceableStatelessWidget {
                                       pushAndTrackBack(
                                         context,
                                         ChoixOrganismeExplainationPage.materialPageRoute(isPoleEmploi: false),
+                                        AnalyticsScreenNames.choixOrganisme,
                                       );
                                     },
                                   ),

--- a/lib/pages/choix_organisme_page.dart
+++ b/lib/pages/choix_organisme_page.dart
@@ -14,14 +14,10 @@ import 'package:pass_emploi_app/widgets/buttons/primary_action_button.dart';
 import 'package:pass_emploi_app/widgets/onboarding_background.dart';
 import 'package:url_launcher/url_launcher.dart';
 
-class ChoixOrganismePage extends TraceableStatelessWidget {
+class ChoixOrganismePage extends StatelessWidget {
+  static const routeName = "/entree/choix-organisme";
+
   static const noOrganismeLink = "https://www.1jeune1solution.gouv.fr/contrat-engagement-jeune";
-
-  const ChoixOrganismePage() : super(name: AnalyticsScreenNames.choixOrganisme);
-
-  static MaterialPageRoute<void> materialPageRoute() {
-    return MaterialPageRoute(builder: (context) => ChoixOrganismePage());
-  }
 
   @override
   Widget build(BuildContext context) {

--- a/lib/pages/credentials_page.dart
+++ b/lib/pages/credentials_page.dart
@@ -5,7 +5,6 @@ import 'package:pass_emploi_app/ui/margins.dart';
 import 'package:pass_emploi_app/widgets/buttons/primary_action_button.dart';
 
 class CredentialsPage extends StatefulWidget {
-
   static const routeName = "/credentials";
 
   @override

--- a/lib/pages/credentials_page.dart
+++ b/lib/pages/credentials_page.dart
@@ -5,11 +5,8 @@ import 'package:pass_emploi_app/ui/margins.dart';
 import 'package:pass_emploi_app/widgets/buttons/primary_action_button.dart';
 
 class CredentialsPage extends StatefulWidget {
-  const CredentialsPage() : super();
 
-  static MaterialPageRoute<void> materialPageRoute() {
-    return MaterialPageRoute(builder: (context) => CredentialsPage());
-  }
+  static const routeName = "/credentials";
 
   @override
   State<CredentialsPage> createState() => _CredentialsPageState();

--- a/lib/pages/entree_page.dart
+++ b/lib/pages/entree_page.dart
@@ -91,7 +91,7 @@ class EntreePage extends TraceableStatelessWidget {
         SizedBox(height: Margins.spacing_base),
         SecondaryButton(
           label: Strings.askAccount,
-          onPressed: () => Navigator.push(context, CejInformationPage.materialPageRoute()),
+          onPressed: () => Navigator.pushNamed(context, CejInformationPage.routeName),
         ),
         SepLine(Margins.spacing_base, 0),
         Theme(

--- a/lib/pages/entree_page.dart
+++ b/lib/pages/entree_page.dart
@@ -86,7 +86,7 @@ class EntreePage extends TraceableStatelessWidget {
       children: [
         PrimaryActionButton(
           label: Strings.loginAction,
-          onPressed: () => Navigator.push(context, LoginPage.materialPageRoute()),
+          onPressed: () => Navigator.pushNamed(context, LoginPage.routeName),
         ),
         SizedBox(height: Margins.spacing_base),
         SecondaryButton(

--- a/lib/pages/favoris/immersion_favoris_page.dart
+++ b/lib/pages/favoris/immersion_favoris_page.dart
@@ -35,6 +35,7 @@ class ImmersionFavorisPage extends AbstractFavorisPage<Immersion, Immersion> {
           itemViewModel.id,
           popPageWhenFavoriIsRemoved: true,
         ),
+        AnalyticsScreenNames.immersionFavoris,
       ),
       from: OffrePage.immersionFavoris,
       id: itemViewModel.id,

--- a/lib/pages/favoris/offre_emploi_favoris_page.dart
+++ b/lib/pages/favoris/offre_emploi_favoris_page.dart
@@ -43,6 +43,7 @@ class OffreEmploiFavorisPage extends AbstractFavorisPage<OffreEmploi, OffreEmplo
           fromAlternance: onlyAlternance,
           popPageWhenFavoriIsRemoved: true,
         ),
+        onlyAlternance ? AnalyticsScreenNames.alternanceFavoris : AnalyticsScreenNames.emploiFavoris,
       ),
     );
   }

--- a/lib/pages/favoris/service_civique_favoris_page.dart
+++ b/lib/pages/favoris/service_civique_favoris_page.dart
@@ -36,9 +36,13 @@ class ServiceCiviqueFavorisPage extends AbstractFavorisPage<ServiceCivique, Serv
           Strings.asSoonAs + itemViewModel.startDate!.toDateTimeUtcOnLocalTimeZone().toDayWithFullMonth()
       ],
       onTap: () {
-        pushAndTrackBack(context, MaterialPageRoute(builder: (_) {
-          return ServiceCiviqueDetailPage(itemViewModel.id, true);
-        }));
+        pushAndTrackBack(
+          context,
+          MaterialPageRoute(builder: (_) {
+            return ServiceCiviqueDetailPage(itemViewModel.id, true);
+          }),
+          AnalyticsScreenNames.immersionFavoris,
+        );
       },
       from: OffrePage.serviceCiviqueFavoris,
       id: itemViewModel.id,

--- a/lib/pages/immersion_list_page.dart
+++ b/lib/pages/immersion_list_page.dart
@@ -115,7 +115,11 @@ class ImmersionListPage extends TraceableStatelessWidget {
       sousTitre: immersion.nomEtablissement,
       lieu: immersion.ville,
       dataTag: [immersion.secteurActivite],
-      onTap: () => pushAndTrackBack(context, ImmersionDetailsPage.materialPageRoute(immersion.id)),
+      onTap: () => pushAndTrackBack(
+        context,
+        ImmersionDetailsPage.materialPageRoute(immersion.id),
+        AnalyticsScreenNames.immersionResults,
+      ),
       from: OffrePage.immersionResults,
       id: immersion.id,
     );
@@ -172,7 +176,11 @@ class ImmersionListPage extends TraceableStatelessWidget {
   }
 
   Future<void> _onFiltreButtonPressed(BuildContext context) {
-    return pushAndTrackBack(context, ImmersionFiltresPage.materialPageRoute());
+    return pushAndTrackBack(
+      context,
+      ImmersionFiltresPage.materialPageRoute(),
+      AnalyticsScreenNames.immersionResults,
+    );
   }
 
   void _trackEmptyResult() {

--- a/lib/pages/immersion_search_page.dart
+++ b/lib/pages/immersion_search_page.dart
@@ -44,7 +44,11 @@ class _ImmersionSearchPageState extends State<ImmersionSearchPage> {
       onWillChange: (_, viewModel) {
         if (_shouldNavigate && viewModel.displayState == ImmersionSearchDisplayState.SHOW_RESULTS) {
           _shouldNavigate = false;
-          widget.pushAndTrackBack(context, MaterialPageRoute(builder: (context) => ImmersionListPage()));
+          widget.pushAndTrackBack(
+            context,
+            MaterialPageRoute(builder: (context) => ImmersionListPage()),
+            AnalyticsScreenNames.immersionResearch,
+          );
         }
       },
       onDispose: (store) {

--- a/lib/pages/login_page.dart
+++ b/lib/pages/login_page.dart
@@ -1,8 +1,6 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_redux/flutter_redux.dart';
 import 'package:flutter_svg/svg.dart';
-import 'package:matomo/matomo.dart';
-import 'package:pass_emploi_app/analytics/analytics_constants.dart';
 import 'package:pass_emploi_app/pages/cej_information_page.dart';
 import 'package:pass_emploi_app/presentation/display_state.dart';
 import 'package:pass_emploi_app/presentation/login_view_model.dart';
@@ -16,12 +14,8 @@ import 'package:pass_emploi_app/widgets/buttons/primary_action_button.dart';
 import 'package:pass_emploi_app/widgets/buttons/secondary_button.dart';
 import 'package:pass_emploi_app/widgets/entree_biseau_background.dart';
 
-class LoginPage extends TraceableStatelessWidget {
-  LoginPage() : super(name: AnalyticsScreenNames.login);
-
-  static MaterialPageRoute<void> materialPageRoute() {
-    return MaterialPageRoute(builder: (context) => LoginPage());
-  }
+class LoginPage extends StatelessWidget {
+  static const routeName = "/login";
 
   @override
   Widget build(BuildContext context) {

--- a/lib/pages/login_page.dart
+++ b/lib/pages/login_page.dart
@@ -78,7 +78,7 @@ class LoginPage extends TraceableStatelessWidget {
                         SizedBox(height: 16),
                         SecondaryButton(
                           label: Strings.askAccount,
-                          onPressed: () => Navigator.push(context, CejInformationPage.materialPageRoute()),
+                          onPressed: () => Navigator.pushNamed(context, CejInformationPage.routeName),
                           backgroundColor: Colors.white,
                         ),
                       ],

--- a/lib/pages/offre_emploi_list_page.dart
+++ b/lib/pages/offre_emploi_list_page.dart
@@ -28,6 +28,9 @@ import 'package:pass_emploi_app/widgets/empty_offre_widget.dart';
 import 'package:pass_emploi_app/widgets/favori_state_selector.dart';
 
 class OffreEmploiListPage extends TraceableStatefulWidget {
+
+  static const routeName = "/recherche/search_results";
+
   final bool onlyAlternance;
   final bool fromSavedSearch;
 

--- a/lib/pages/offre_emploi_list_page.dart
+++ b/lib/pages/offre_emploi_list_page.dart
@@ -27,15 +27,13 @@ import 'package:pass_emploi_app/widgets/default_app_bar.dart';
 import 'package:pass_emploi_app/widgets/empty_offre_widget.dart';
 import 'package:pass_emploi_app/widgets/favori_state_selector.dart';
 
-class OffreEmploiListPage extends TraceableStatefulWidget {
-
+class OffreEmploiListPage extends StatefulWidget {
   static const routeName = "/recherche/search_results";
 
   final bool onlyAlternance;
   final bool fromSavedSearch;
 
-  OffreEmploiListPage({required this.onlyAlternance, this.fromSavedSearch = false})
-      : super(name: onlyAlternance ? AnalyticsScreenNames.alternanceResults : AnalyticsScreenNames.emploiResults);
+  OffreEmploiListPage({required this.onlyAlternance, this.fromSavedSearch = false});
 
   @override
   State<OffreEmploiListPage> createState() => _OffreEmploiListPageState();

--- a/lib/pages/offre_emploi_list_page.dart
+++ b/lib/pages/offre_emploi_list_page.dart
@@ -241,6 +241,7 @@ class _OffreEmploiListPageState extends State<OffreEmploiListPage> {
         .pushAndTrackBack(
           context,
           OffreEmploiDetailsPage.materialPageRoute(offreId, fromAlternance: widget.onlyAlternance),
+          widget.onlyAlternance ? AnalyticsScreenNames.alternanceResults : AnalyticsScreenNames.emploiResults,
         )
         .then((_) => _scrollController.jumpTo(_offsetBeforeLoading));
   }
@@ -269,7 +270,11 @@ class _OffreEmploiListPageState extends State<OffreEmploiListPage> {
 
   Future<void> _onFiltreButtonPressed() {
     return widget
-        .pushAndTrackBack(context, OffreEmploiFiltresPage.materialPageRoute(widget.onlyAlternance))
+        .pushAndTrackBack(
+      context,
+      OffreEmploiFiltresPage.materialPageRoute(widget.onlyAlternance),
+      widget.onlyAlternance ? AnalyticsScreenNames.alternanceResults : AnalyticsScreenNames.emploiResults,
+    )
         .then((value) {
       if (value == true) {
         _offsetBeforeLoading = 0;

--- a/lib/pages/offre_emploi_search_page.dart
+++ b/lib/pages/offre_emploi_search_page.dart
@@ -43,9 +43,13 @@ class _OffreEmploiSearchPageState extends State<OffreEmploiSearchPage> {
       onWillChange: (_, newViewModel) {
         if (newViewModel.displayState == DisplayState.CONTENT && _shouldNavigate) {
           _shouldNavigate = false;
-          widget.pushAndTrackBack(context, MaterialPageRoute(builder: (_) {
-            return OffreEmploiListPage(onlyAlternance: widget.onlyAlternance);
-          })).then((_) {
+          widget.pushAndTrackBack(
+            context,
+            MaterialPageRoute(builder: (_) {
+              return OffreEmploiListPage(onlyAlternance: widget.onlyAlternance);
+            }),
+            widget.onlyAlternance ? AnalyticsScreenNames.alternanceResearch : AnalyticsScreenNames.emploiResearch,
+          ).then((_) {
             _shouldNavigate = true;
           });
         }

--- a/lib/pages/offre_emploi_search_page.dart
+++ b/lib/pages/offre_emploi_search_page.dart
@@ -2,7 +2,6 @@ import 'package:flutter/material.dart';
 import 'package:flutter_redux/flutter_redux.dart';
 import 'package:matomo/matomo.dart';
 import 'package:pass_emploi_app/analytics/analytics_constants.dart';
-import 'package:pass_emploi_app/analytics/analytics_extensions.dart';
 import 'package:pass_emploi_app/features/location/search_location_actions.dart';
 import 'package:pass_emploi_app/pages/offre_emploi_list_page.dart';
 import 'package:pass_emploi_app/presentation/display_state.dart';
@@ -43,13 +42,11 @@ class _OffreEmploiSearchPageState extends State<OffreEmploiSearchPage> {
       onWillChange: (_, newViewModel) {
         if (newViewModel.displayState == DisplayState.CONTENT && _shouldNavigate) {
           _shouldNavigate = false;
-          widget.pushAndTrackBack(
+          Navigator.pushNamed(
             context,
-            MaterialPageRoute(builder: (_) {
-              return OffreEmploiListPage(onlyAlternance: widget.onlyAlternance);
-            }),
-            widget.onlyAlternance ? AnalyticsScreenNames.alternanceResearch : AnalyticsScreenNames.emploiResearch,
-          ).then((_) {
+            OffreEmploiListPage.routeName,
+            arguments: {"onlyAlternance": widget.onlyAlternance},
+          ).then((value) {
             _shouldNavigate = true;
           });
         }

--- a/lib/pages/rendezvous/rendezvous_list_page.dart
+++ b/lib/pages/rendezvous/rendezvous_list_page.dart
@@ -34,14 +34,22 @@ class RendezvousListPage extends TraceableStatelessWidget {
     return _Scaffold(
       body: _Body(
         viewModel: viewModel,
-        onTap: (rdvId) => pushAndTrackBack(context, RendezvousDetailsPage.materialPageRoute(rdvId)),
+        onTap: (rdvId) => pushAndTrackBack(
+          context,
+          RendezvousDetailsPage.materialPageRoute(rdvId),
+          AnalyticsScreenNames.rendezvousList,
+        ),
       ),
     );
   }
 
   void _openDeeplinkIfNeeded(RendezvousListViewModel viewModel, BuildContext context) {
     if (viewModel.deeplinkRendezvousId != null) {
-      pushAndTrackBack(context, RendezvousDetailsPage.materialPageRoute(viewModel.deeplinkRendezvousId!));
+      pushAndTrackBack(
+        context,
+        RendezvousDetailsPage.materialPageRoute(viewModel.deeplinkRendezvousId!),
+        AnalyticsScreenNames.rendezvousList,
+      );
       viewModel.onDeeplinkUsed();
     }
   }

--- a/lib/pages/router_page.dart
+++ b/lib/pages/router_page.dart
@@ -11,6 +11,8 @@ import 'package:pass_emploi_app/presentation/router_page_view_model.dart';
 import 'package:pass_emploi_app/redux/app_state.dart';
 
 class RouterPage extends StatefulWidget {
+  static const routeName = "/router";
+
   @override
   State<RouterPage> createState() => _RouterPageState();
 }

--- a/lib/pages/saved_search_tab_page.dart
+++ b/lib/pages/saved_search_tab_page.dart
@@ -67,10 +67,20 @@ class _SavedSearchTabPageState extends State<SavedSearchTabPage> {
     if (!_shouldNavigate || newViewModel == null) return;
     switch (newViewModel.searchNavigationState) {
       case SavedSearchNavigationState.OFFRE_EMPLOI:
-        _goToPage(context, _indexOfOffresEmploi, OffreEmploiListPage(onlyAlternance: false, fromSavedSearch: true));
+        _shouldNavigate = false;
+        _updateIndex(_indexOfOffresEmploi);
+        Navigator.pushNamed(context, OffreEmploiListPage.routeName, arguments: {
+          "onlyAlternance": false,
+          "fromSavedSearch": true,
+        }).then((_) => _shouldNavigate = true);
         break;
       case SavedSearchNavigationState.OFFRE_ALTERNANCE:
-        _goToPage(context, _indexOfAlternance, OffreEmploiListPage(onlyAlternance: true, fromSavedSearch: true));
+        _shouldNavigate = false;
+        _updateIndex(_indexOfAlternance);
+        Navigator.pushNamed(context, OffreEmploiListPage.routeName, arguments: {
+          "onlyAlternance": true,
+          "fromSavedSearch": true,
+        }).then((_) => _shouldNavigate = true);
         break;
       case SavedSearchNavigationState.OFFRE_IMMERSION:
         _goToPage(context, _indexOfImmersion, ImmersionListPage(true))

--- a/lib/pages/saved_search_tab_page.dart
+++ b/lib/pages/saved_search_tab_page.dart
@@ -67,37 +67,41 @@ class _SavedSearchTabPageState extends State<SavedSearchTabPage> {
     if (!_shouldNavigate || newViewModel == null) return;
     switch (newViewModel.searchNavigationState) {
       case SavedSearchNavigationState.OFFRE_EMPLOI:
-        _shouldNavigate = false;
-        _updateIndex(_indexOfOffresEmploi);
-        Navigator.pushNamed(context, OffreEmploiListPage.routeName, arguments: {
-          "onlyAlternance": false,
-          "fromSavedSearch": true,
-        }).then((_) => _shouldNavigate = true);
+        _goToPageNamed(
+          _indexOfOffresEmploi,
+          OffreEmploiListPage.routeName,
+          arguments: {"onlyAlternance": false, "fromSavedSearch": true},
+        );
         break;
       case SavedSearchNavigationState.OFFRE_ALTERNANCE:
-        _shouldNavigate = false;
-        _updateIndex(_indexOfAlternance);
-        Navigator.pushNamed(context, OffreEmploiListPage.routeName, arguments: {
-          "onlyAlternance": true,
-          "fromSavedSearch": true,
-        }).then((_) => _shouldNavigate = true);
+        _goToPageNamed(
+          _indexOfAlternance,
+          OffreEmploiListPage.routeName,
+          arguments: {"onlyAlternance": true, "fromSavedSearch": true},
+        );
         break;
       case SavedSearchNavigationState.OFFRE_IMMERSION:
-        _goToPage(context, _indexOfImmersion, ImmersionListPage(true))
+        _goToPage(_indexOfImmersion, ImmersionListPage(true))
             .then((value) => StoreProvider.of<AppState>(context).dispatch(ImmersionListResetAction()));
         break;
       case SavedSearchNavigationState.SERVICE_CIVIQUE:
-        _goToPage(context, _indexOfServiceCivique, ServiceCiviqueListPage(true));
+        _goToPage(_indexOfServiceCivique, ServiceCiviqueListPage(true));
         break;
       case SavedSearchNavigationState.NONE:
         break;
     }
   }
 
-  Future<bool> _goToPage(BuildContext context, int newIndex, Widget page) {
+  Future<bool> _goToPage(int newIndex, Widget page) {
     _shouldNavigate = false;
     _updateIndex(newIndex, true);
     return Navigator.push(context, MaterialPageRoute(builder: (_) => page)).then((_) => _shouldNavigate = true);
+  }
+
+  Future<bool> _goToPageNamed(int newIndex, String routeName, {Object? arguments}) {
+    _shouldNavigate = false;
+    _updateIndex(newIndex, true);
+    return Navigator.pushNamed(context, routeName, arguments: arguments).then((_) => _shouldNavigate = true);
   }
 
   Widget _scrollView(SavedSearchListViewModel viewModel) {

--- a/lib/pages/service_civique/service_civique_list_page.dart
+++ b/lib/pages/service_civique/service_civique_list_page.dart
@@ -151,9 +151,13 @@ class _ServiceCiviqueListPage extends State<ServiceCiviqueListPage> {
       ],
       from: OffrePage.serviceCiviqueResults,
       onTap: () {
-        widget.pushAndTrackBack(context, MaterialPageRoute(builder: (_) {
-          return ServiceCiviqueDetailPage(item.id);
-        }));
+        widget.pushAndTrackBack(
+          context,
+          MaterialPageRoute(builder: (_) {
+            return ServiceCiviqueDetailPage(item.id);
+          }),
+          AnalyticsScreenNames.serviceCiviqueResults,
+        );
       },
     );
   }
@@ -274,7 +278,13 @@ class _ServiceCiviqueListPage extends State<ServiceCiviqueListPage> {
   }
 
   Future<void> _onFiltreButtonPressed() async {
-    return widget.pushAndTrackBack(context, ServiceCiviqueFiltresPage.materialPageRoute()).then((value) {
+    return widget
+        .pushAndTrackBack(
+      context,
+      ServiceCiviqueFiltresPage.materialPageRoute(),
+      AnalyticsScreenNames.serviceCiviqueResults,
+    )
+        .then((value) {
       if (value == true) {
         _offsetBeforeLoading = 0;
         if (_scrollController.hasClients) _scrollController.jumpTo(_offsetBeforeLoading);

--- a/lib/pages/service_civique/service_civique_search_page.dart
+++ b/lib/pages/service_civique/service_civique_search_page.dart
@@ -37,7 +37,11 @@ class _ServiceCiviqueSearchPageState extends State<ServiceCiviqueSearchPage> {
         if (newViewModel.displayState == DisplayState.CONTENT) {
           if (_shouldNavigate) {
             _shouldNavigate = false;
-            widget.pushAndTrackBack(context, MaterialPageRoute(builder: (context) => ServiceCiviqueListPage()));
+            widget.pushAndTrackBack(
+              context,
+              MaterialPageRoute(builder: (context) => ServiceCiviqueListPage()),
+              AnalyticsScreenNames.serviceCiviqueResearch,
+            );
           }
         }
       },

--- a/lib/pass_emploi_app.dart
+++ b/lib/pass_emploi_app.dart
@@ -27,15 +27,18 @@ class PassEmploiApp extends StatelessWidget {
           title: Strings.appName,
           theme: PassEmploiTheme.data,
           initialRoute: RouterPage.routeName,
-          routes: {
-            RouterPage.routeName: (context) => RouterPage(),
-            CejInformationPage.routeName: (context) => CejInformationPage(),
-            CredentialsPage.routeName: (context) => CredentialsPage(),
-            ChoixOrganismePage.routeName: (context) => ChoixOrganismePage(),
-            LoginPage.routeName: (context) => LoginPage(),
-          },
           onGenerateRoute: (settings) {
-            if (settings.name == OffreEmploiListPage.routeName) {
+            if (settings.name == RouterPage.routeName) {
+              return MaterialPageRoute(builder: (context) => RouterPage());
+            } else if (settings.name == CejInformationPage.routeName) {
+              return MaterialPageRoute(builder: (context) => CejInformationPage());
+            } else if (settings.name == CredentialsPage.routeName) {
+              return MaterialPageRoute(builder: (context) => CredentialsPage());
+            } else if (settings.name == ChoixOrganismePage.routeName) {
+              return MaterialPageRoute(builder: (context) => ChoixOrganismePage());
+            } else if (settings.name == LoginPage.routeName) {
+              return MaterialPageRoute(builder: (context) => LoginPage());
+            } else if (settings.name == OffreEmploiListPage.routeName) {
               final args = settings.arguments as Map<String, dynamic>;
               return MaterialPageRoute(
                 builder: (context) => OffreEmploiListPage(
@@ -44,6 +47,8 @@ class PassEmploiApp extends StatelessWidget {
                 ),
                 settings: settings,
               );
+            } else {
+              return null;
             }
           },
           localizationsDelegates: [

--- a/lib/pass_emploi_app.dart
+++ b/lib/pass_emploi_app.dart
@@ -5,6 +5,7 @@ import 'package:pass_emploi_app/pages/cej_information_page.dart';
 import 'package:pass_emploi_app/pages/choix_organisme_page.dart';
 import 'package:pass_emploi_app/pages/credentials_page.dart';
 import 'package:pass_emploi_app/pages/login_page.dart';
+import 'package:pass_emploi_app/pages/offre_emploi_list_page.dart';
 import 'package:pass_emploi_app/pages/router_page.dart';
 import 'package:pass_emploi_app/redux/app_state.dart';
 import 'package:pass_emploi_app/ui/strings.dart';
@@ -32,6 +33,18 @@ class PassEmploiApp extends StatelessWidget {
             CredentialsPage.routeName: (context) => CredentialsPage(),
             ChoixOrganismePage.routeName: (context) => ChoixOrganismePage(),
             LoginPage.routeName: (context) => LoginPage(),
+          },
+          onGenerateRoute: (settings) {
+            if (settings.name == OffreEmploiListPage.routeName) {
+              final args = settings.arguments as Map<String, dynamic>;
+              return MaterialPageRoute(
+                builder: (context) => OffreEmploiListPage(
+                  onlyAlternance: args["onlyAlternance"] as bool,
+                  fromSavedSearch: (args["fromSavedSearch"] ?? false) as bool,
+                ),
+                settings: settings,
+              );
+            }
           },
           localizationsDelegates: [
             GlobalMaterialLocalizations.delegate,

--- a/lib/pass_emploi_app.dart
+++ b/lib/pass_emploi_app.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_localizations/flutter_localizations.dart';
 import 'package:flutter_redux/flutter_redux.dart';
+import 'package:pass_emploi_app/pages/cej_information_page.dart';
 import 'package:pass_emploi_app/pages/router_page.dart';
 import 'package:pass_emploi_app/redux/app_state.dart';
 import 'package:pass_emploi_app/ui/strings.dart';
@@ -23,7 +24,8 @@ class PassEmploiApp extends StatelessWidget {
           theme: PassEmploiTheme.data,
           initialRoute: RouterPage.routeName,
           routes: {
-            RouterPage.routeName: (context) => RouterPage()
+            RouterPage.routeName: (context) => RouterPage(),
+            CejInformationPage.routeName: (context) => CejInformationPage(),
           },
           localizationsDelegates: [
             GlobalMaterialLocalizations.delegate,

--- a/lib/pass_emploi_app.dart
+++ b/lib/pass_emploi_app.dart
@@ -29,6 +29,7 @@ class PassEmploiApp extends StatelessWidget {
             RouterPage.routeName: (context) => RouterPage(),
             CejInformationPage.routeName: (context) => CejInformationPage(),
             CredentialsPage.routeName: (context) => CredentialsPage(),
+            ChoixOrganismePage.routeName: (context) => ChoixOrganismePage(),
           },
           localizationsDelegates: [
             GlobalMaterialLocalizations.delegate,

--- a/lib/pass_emploi_app.dart
+++ b/lib/pass_emploi_app.dart
@@ -1,11 +1,7 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_localizations/flutter_localizations.dart';
 import 'package:flutter_redux/flutter_redux.dart';
-import 'package:pass_emploi_app/pages/cej_information_page.dart';
-import 'package:pass_emploi_app/pages/choix_organisme_page.dart';
-import 'package:pass_emploi_app/pages/credentials_page.dart';
-import 'package:pass_emploi_app/pages/login_page.dart';
-import 'package:pass_emploi_app/pages/offre_emploi_list_page.dart';
+import 'package:pass_emploi_app/app_router.dart';
 import 'package:pass_emploi_app/pages/router_page.dart';
 import 'package:pass_emploi_app/redux/app_state.dart';
 import 'package:pass_emploi_app/ui/strings.dart';
@@ -15,6 +11,7 @@ import 'package:redux/redux.dart';
 
 class PassEmploiApp extends StatelessWidget {
   final Store<AppState> _store;
+  final _router = AppRouter();
 
   PassEmploiApp(this._store);
 
@@ -23,43 +20,21 @@ class PassEmploiApp extends StatelessWidget {
     return StoreProvider<AppState>(
       store: _store,
       child: MaterialApp(
-          scaffoldMessengerKey: snackbarKey,
-          title: Strings.appName,
-          theme: PassEmploiTheme.data,
-          initialRoute: RouterPage.routeName,
-          onGenerateRoute: (settings) {
-            if (settings.name == RouterPage.routeName) {
-              return MaterialPageRoute(builder: (context) => RouterPage());
-            } else if (settings.name == CejInformationPage.routeName) {
-              return MaterialPageRoute(builder: (context) => CejInformationPage());
-            } else if (settings.name == CredentialsPage.routeName) {
-              return MaterialPageRoute(builder: (context) => CredentialsPage());
-            } else if (settings.name == ChoixOrganismePage.routeName) {
-              return MaterialPageRoute(builder: (context) => ChoixOrganismePage());
-            } else if (settings.name == LoginPage.routeName) {
-              return MaterialPageRoute(builder: (context) => LoginPage());
-            } else if (settings.name == OffreEmploiListPage.routeName) {
-              final args = settings.arguments as Map<String, dynamic>;
-              return MaterialPageRoute(
-                builder: (context) => OffreEmploiListPage(
-                  onlyAlternance: args["onlyAlternance"] as bool,
-                  fromSavedSearch: (args["fromSavedSearch"] ?? false) as bool,
-                ),
-                settings: settings,
-              );
-            } else {
-              return null;
-            }
-          },
-          localizationsDelegates: [
-            GlobalMaterialLocalizations.delegate,
-            GlobalWidgetsLocalizations.delegate,
-            GlobalCupertinoLocalizations.delegate,
-          ],
-          supportedLocales: [
-            Locale('en'),
-            Locale('fr'),
-          ]),
+        scaffoldMessengerKey: snackbarKey,
+        title: Strings.appName,
+        theme: PassEmploiTheme.data,
+        initialRoute: RouterPage.routeName,
+        onGenerateRoute: (settings) => _router.getMaterialPageRoute(settings),
+        localizationsDelegates: [
+          GlobalMaterialLocalizations.delegate,
+          GlobalWidgetsLocalizations.delegate,
+          GlobalCupertinoLocalizations.delegate,
+        ],
+        supportedLocales: [
+          Locale('en'),
+          Locale('fr'),
+        ],
+      ),
     );
   }
 }

--- a/lib/pass_emploi_app.dart
+++ b/lib/pass_emploi_app.dart
@@ -2,6 +2,7 @@ import 'package:flutter/material.dart';
 import 'package:flutter_localizations/flutter_localizations.dart';
 import 'package:flutter_redux/flutter_redux.dart';
 import 'package:pass_emploi_app/pages/cej_information_page.dart';
+import 'package:pass_emploi_app/pages/credentials_page.dart';
 import 'package:pass_emploi_app/pages/router_page.dart';
 import 'package:pass_emploi_app/redux/app_state.dart';
 import 'package:pass_emploi_app/ui/strings.dart';
@@ -26,6 +27,7 @@ class PassEmploiApp extends StatelessWidget {
           routes: {
             RouterPage.routeName: (context) => RouterPage(),
             CejInformationPage.routeName: (context) => CejInformationPage(),
+            CredentialsPage.routeName: (context) => CredentialsPage(),
           },
           localizationsDelegates: [
             GlobalMaterialLocalizations.delegate,

--- a/lib/pass_emploi_app.dart
+++ b/lib/pass_emploi_app.dart
@@ -21,7 +21,10 @@ class PassEmploiApp extends StatelessWidget {
           scaffoldMessengerKey: snackbarKey,
           title: Strings.appName,
           theme: PassEmploiTheme.data,
-          home: RouterPage(),
+          initialRoute: RouterPage.routeName,
+          routes: {
+            RouterPage.routeName: (context) => RouterPage()
+          },
           localizationsDelegates: [
             GlobalMaterialLocalizations.delegate,
             GlobalWidgetsLocalizations.delegate,

--- a/lib/pass_emploi_app.dart
+++ b/lib/pass_emploi_app.dart
@@ -4,6 +4,7 @@ import 'package:flutter_redux/flutter_redux.dart';
 import 'package:pass_emploi_app/pages/cej_information_page.dart';
 import 'package:pass_emploi_app/pages/choix_organisme_page.dart';
 import 'package:pass_emploi_app/pages/credentials_page.dart';
+import 'package:pass_emploi_app/pages/login_page.dart';
 import 'package:pass_emploi_app/pages/router_page.dart';
 import 'package:pass_emploi_app/redux/app_state.dart';
 import 'package:pass_emploi_app/ui/strings.dart';
@@ -30,6 +31,7 @@ class PassEmploiApp extends StatelessWidget {
             CejInformationPage.routeName: (context) => CejInformationPage(),
             CredentialsPage.routeName: (context) => CredentialsPage(),
             ChoixOrganismePage.routeName: (context) => ChoixOrganismePage(),
+            LoginPage.routeName: (context) => LoginPage(),
           },
           localizationsDelegates: [
             GlobalMaterialLocalizations.delegate,

--- a/lib/pass_emploi_app.dart
+++ b/lib/pass_emploi_app.dart
@@ -2,6 +2,7 @@ import 'package:flutter/material.dart';
 import 'package:flutter_localizations/flutter_localizations.dart';
 import 'package:flutter_redux/flutter_redux.dart';
 import 'package:pass_emploi_app/pages/cej_information_page.dart';
+import 'package:pass_emploi_app/pages/choix_organisme_page.dart';
 import 'package:pass_emploi_app/pages/credentials_page.dart';
 import 'package:pass_emploi_app/pages/router_page.dart';
 import 'package:pass_emploi_app/redux/app_state.dart';

--- a/lib/presentation/rendezvous/rendezvous_details_view_model.dart
+++ b/lib/presentation/rendezvous/rendezvous_details_view_model.dart
@@ -81,7 +81,7 @@ class RendezvousDetailsViewModel extends Equatable {
       trackingPageName: _trackingPageName(rdv.type.code),
       commentTitle: _commentTitle(rdv, comment),
       comment: comment,
-      organism: _shouldHidePresentielInformations(rdv) ? null : rdv.organism,
+      organism: _shouldHidePresentielInformation(rdv) ? null : rdv.organism,
       address: address,
       phone: rdv.phone != null ? Strings.phone(rdv.phone!) : null,
       addressRedirectUri: address != null ? UriHandler().mapsUri(address, platform) : null,
@@ -120,7 +120,7 @@ class RendezvousDetailsViewModel extends Equatable {
 
 enum VisioButtonState { ACTIVE, INACTIVE, HIDDEN }
 
-bool _shouldHidePresentielInformations(Rendezvous rdv) {
+bool _shouldHidePresentielInformation(Rendezvous rdv) {
   return rdv.isInVisio || rdv.modalityType() == RendezvousModalityType.TELEPHONE;
 }
 
@@ -131,7 +131,7 @@ bool _shouldDisplayConseillerPresence(Rendezvous rdv) {
 }
 
 String? _address(Rendezvous rdv) {
-  return _shouldHidePresentielInformations(rdv) ? null : rdv.address;
+  return _shouldHidePresentielInformation(rdv) ? null : rdv.address;
 }
 
 String _hourAndDuration(Rendezvous rdv) {

--- a/test/analytics/analytics_screen_tracking_test.dart
+++ b/test/analytics/analytics_screen_tracking_test.dart
@@ -14,6 +14,17 @@ void main() {
     expect(tracking, "login");
   });
 
+  test("choix organisme tracking", () {
+    // Given
+    final settings = RouteSettings(name: "/entree/choix-organisme");
+
+    // When
+    final tracking = AnalyticsScreenTracking.onGenerateScreenTracking(settings);
+
+    // Then
+    expect(tracking, "entree/choix-organisme");
+  });
+
   test("offres emploi results tracking", () {
     // Given
     final settings = RouteSettings(name: "/recherche/search_results", arguments: {"onlyAlternance": false});
@@ -34,5 +45,16 @@ void main() {
 
     // Then
     expect(tracking, "recherche/alternance/search_results");
+  });
+
+  test("router should not be tracked", () {
+    // Given
+    final settings = RouteSettings(name: "/router");
+
+    // When
+    final tracking = AnalyticsScreenTracking.onGenerateScreenTracking(settings);
+
+    // Then
+    expect(tracking, isNull);
   });
 }

--- a/test/analytics/analytics_screen_tracking_test.dart
+++ b/test/analytics/analytics_screen_tracking_test.dart
@@ -1,0 +1,38 @@
+import 'package:flutter/cupertino.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:pass_emploi_app/analytics/analytics_screen_tracking.dart';
+
+void main() {
+  test("login tracking", () {
+    // Given
+    final settings = RouteSettings(name: "/login");
+
+    // When
+    final tracking = AnalyticsScreenTracking.onGenerateScreenTracking(settings);
+
+    // Then
+    expect(tracking, "login");
+  });
+
+  test("offres emploi results tracking", () {
+    // Given
+    final settings = RouteSettings(name: "/recherche/search_results", arguments: {"onlyAlternance": false});
+
+    // When
+    final tracking = AnalyticsScreenTracking.onGenerateScreenTracking(settings);
+
+    // Then
+    expect(tracking, "recherche/emploi/search_results");
+  });
+
+  test("offres alternance results tracking", () {
+    // Given
+    final settings = RouteSettings(name: "/recherche/search_results", arguments: {"onlyAlternance": true});
+
+    // When
+    final tracking = AnalyticsScreenTracking.onGenerateScreenTracking(settings);
+
+    // Then
+    expect(tracking, "recherche/alternance/search_results");
+  });
+}

--- a/test/analytics/analytics_screen_tracking_test.dart
+++ b/test/analytics/analytics_screen_tracking_test.dart
@@ -3,58 +3,27 @@ import 'package:flutter_test/flutter_test.dart';
 import 'package:pass_emploi_app/analytics/analytics_screen_tracking.dart';
 
 void main() {
-  test("login tracking", () {
-    // Given
-    final settings = RouteSettings(name: "/login");
+  group("onGenerateScreenTracking should properly build tracking page depending on route settings", () {
+    void assertTracking(RouteSettings settings, String? expectedTracking) {
+      test("${settings.name} with args ${settings.arguments} -> $expectedTracking", () async {
+        // When
+        final tracking = AnalyticsScreenTracking.onGenerateScreenTracking(settings);
 
-    // When
-    final tracking = AnalyticsScreenTracking.onGenerateScreenTracking(settings);
+        // Then
+        expect(tracking, expectedTracking);
+      });
+    }
 
-    // Then
-    expect(tracking, "login");
-  });
-
-  test("choix organisme tracking", () {
-    // Given
-    final settings = RouteSettings(name: "/entree/choix-organisme");
-
-    // When
-    final tracking = AnalyticsScreenTracking.onGenerateScreenTracking(settings);
-
-    // Then
-    expect(tracking, "entree/choix-organisme");
-  });
-
-  test("offres emploi results tracking", () {
-    // Given
-    final settings = RouteSettings(name: "/recherche/search_results", arguments: {"onlyAlternance": false});
-
-    // When
-    final tracking = AnalyticsScreenTracking.onGenerateScreenTracking(settings);
-
-    // Then
-    expect(tracking, "recherche/emploi/search_results");
-  });
-
-  test("offres alternance results tracking", () {
-    // Given
-    final settings = RouteSettings(name: "/recherche/search_results", arguments: {"onlyAlternance": true});
-
-    // When
-    final tracking = AnalyticsScreenTracking.onGenerateScreenTracking(settings);
-
-    // Then
-    expect(tracking, "recherche/alternance/search_results");
-  });
-
-  test("router should not be tracked", () {
-    // Given
-    final settings = RouteSettings(name: "/router");
-
-    // When
-    final tracking = AnalyticsScreenTracking.onGenerateScreenTracking(settings);
-
-    // Then
-    expect(tracking, isNull);
+    assertTracking(RouteSettings(name: "/router"), null);
+    assertTracking(RouteSettings(name: "/login"), "login");
+    assertTracking(RouteSettings(name: "/entree/choix-organisme"), "entree/choix-organisme");
+    assertTracking(
+      RouteSettings(name: "/recherche/search_results", arguments: {"onlyAlternance": false}),
+      "recherche/emploi/search_results",
+    );
+    assertTracking(
+      RouteSettings(name: "/recherche/search_results", arguments: {"onlyAlternance": true}),
+      "recherche/alternance/search_results",
+    );
   });
 }


### PR DESCRIPTION
Une première proposition pour les cas où l'écran a besoin de paramètres pour être construit.

J'ai pas trop voulu m'embêter à faire une classe `OffreEmploiListPageArguments` qui aurait l'avantage d'avoir des arguments fortement typés, mais le désavatange d'être assez lourde à écrire.

J'ai aussi rajouté des TUs très basiques sur le tracking, vu qu'on peut maintenant :)

Sur le dernier commit (e78ee21266c1757b6d729ffa9d308eba47544fe7) j'ai décidé de n'utiliser que le champ `onGenerateRoute` pour faire la mapping nom => route, mais on pourrait avoir un mix de `routes` pour les cas simples et `onGenerateRoute` pour les cas avec paramètres. 

Super preneur de vos avis !

