### PR TITLE
[FIX] 514 - Suppression de la notion de "requester" au niveau du logout

### DIFF
--- a/lib/auth/auth_access_checker.dart
+++ b/lib/auth/auth_access_checker.dart
@@ -7,7 +7,7 @@ class AuthAccessChecker {
 
   void logoutUserIfTokenIsExpired(String? message, int statusCode) {
     if (message == 'token_pole_emploi_expired' && statusCode == 401) {
-      _store.dispatch(RequestLogoutAction(LogoutRequester.SYSTEM));
+      _store.dispatch(RequestLogoutAction());
     }
   }
 

--- a/lib/auth/auth_access_token_retriever.dart
+++ b/lib/auth/auth_access_token_retriever.dart
@@ -18,7 +18,7 @@ class AuthAccessTokenRetriever {
       case RefreshTokenStatus.SUCCESSFUL:
         return (await _authenticator.accessToken())!;
       case RefreshTokenStatus.EXPIRED_REFRESH_TOKEN:
-        _store.dispatch(RequestLogoutAction(LogoutRequester.SYSTEM));
+        _store.dispatch(RequestLogoutAction());
         throw Exception("ID Token is null");
       default:
         throw Exception(refreshTokenStatus);

--- a/lib/features/login/login_actions.dart
+++ b/lib/features/login/login_actions.dart
@@ -1,7 +1,6 @@
 import 'package:pass_emploi_app/models/user.dart';
 
 enum RequestLoginMode { PASS_EMPLOI, SIMILO, POLE_EMPLOI }
-enum LogoutRequester { SYSTEM, USER }
 
 class LoginRequestAction {}
 
@@ -25,8 +24,4 @@ class RequestLoginAction {
   RequestLoginAction(this.mode);
 }
 
-class RequestLogoutAction {
-  final LogoutRequester logoutRequester;
-
-  RequestLogoutAction(this.logoutRequester);
-}
+class RequestLogoutAction {}

--- a/lib/features/login/login_middleware.dart
+++ b/lib/features/login/login_middleware.dart
@@ -22,8 +22,7 @@ class LoginMiddleware extends MiddlewareClass<AppState> {
     } else if (action is RequestLoginAction) {
       _logUser(store, action.mode);
     } else if (action is RequestLogoutAction) {
-      _logout(store, action.logoutRequester);
-      _firebaseAuthWrapper.signOut();
+      _logout(store);
     }
   }
 
@@ -59,10 +58,11 @@ class LoginMiddleware extends MiddlewareClass<AppState> {
     store.dispatch(LoginSuccessAction(user));
   }
 
-  void _logout(Store<AppState> store, LogoutRequester logoutRequester) async {
-    if (logoutRequester == LogoutRequester.USER) await _authenticator.logout();
+  void _logout(Store<AppState> store) async {
+    await _authenticator.logout();
     store.dispatch(UnsubscribeFromChatStatusAction());
     store.dispatch(BootstrapAction());
+    _firebaseAuthWrapper.signOut();
   }
 
   AuthenticationMode _getAuthenticationMode(RequestLoginMode mode) {

--- a/lib/pages/profil/profil_page.dart
+++ b/lib/pages/profil/profil_page.dart
@@ -135,7 +135,7 @@ class ProfilPage extends TraceableStatelessWidget {
               SizedBox(height: Margins.spacing_m),
               SecondaryButton(
                 onPressed: () {
-                  StoreProvider.of<AppState>(context).dispatch(RequestLogoutAction(LogoutRequester.USER));
+                  StoreProvider.of<AppState>(context).dispatch(RequestLogoutAction());
                 },
                 label: Strings.logoutAction,
               ),

--- a/test/auth/auth_access_checker_test.dart
+++ b/test/auth/auth_access_checker_test.dart
@@ -20,7 +20,6 @@ void main() {
         // Then
         if (expectLogout) {
           expect(store.dispatchedAction, isA<RequestLogoutAction>());
-          expect((store.dispatchedAction as RequestLogoutAction).logoutRequester, LogoutRequester.SYSTEM);
         } else {
           expect(store.dispatchedAction, isNull);
         }

--- a/test/auth/auth_access_token_retriever_test.dart
+++ b/test/auth/auth_access_token_retriever_test.dart
@@ -85,7 +85,6 @@ void main() {
 
     // Then
     expect(store.dispatchedAction, isA<RequestLogoutAction>());
-    expect((store.dispatchedAction as RequestLogoutAction).logoutRequester, LogoutRequester.SYSTEM);
   });
 }
 

--- a/test/feature/login/login_test.dart
+++ b/test/feature/login/login_test.dart
@@ -160,7 +160,7 @@ void main() {
     });
   });
 
-  test("On SYSTEM logout, state is fully reset except for configuration", () async {
+  test("On logout, user is logged out from authenticator and state is fully reset except for configuration", () async {
     // Given
     final authenticatorSpy = AuthenticatorSpy();
     factory.authenticator = authenticatorSpy;
@@ -173,31 +173,7 @@ void main() {
     final Future<AppState> newStateFuture = store.onChange.first;
 
     // When
-    store.dispatch(RequestLogoutAction(LogoutRequester.SYSTEM));
-
-    // Then
-    final newState = await newStateFuture;
-    expect(newState.loginState is LoginNotInitializedState, isTrue);
-    expect(newState.rendezvousState is RendezvousNotInitializedState, isTrue);
-    expect(newState.configurationState.getFlavor(), Flavor.PROD);
-    expect(authenticatorSpy.logoutCalled, isFalse);
-  });
-
-  test("On USER logout, user is logged out from authenticator and state is fully reset except for configuration",
-      () async {
-    // Given
-    final authenticatorSpy = AuthenticatorSpy();
-    factory.authenticator = authenticatorSpy;
-    final store = factory.initializeReduxStore(
-      initialState: AppState.initialState(configuration: configuration(flavor: Flavor.PROD)).copyWith(
-        loginState: UserNotLoggedInState(),
-        rendezvousState: RendezvousLoadingState(),
-      ),
-    );
-    final Future<AppState> newStateFuture = store.onChange.first;
-
-    // When
-    store.dispatch(RequestLogoutAction(LogoutRequester.USER));
+    store.dispatch(RequestLogoutAction());
 
     // Then
     final newState = await newStateFuture;

--- a/test/feature/login/post_logout_clear_pole_emploi_token_test.dart
+++ b/test/feature/login/post_logout_clear_pole_emploi_token_test.dart
@@ -18,7 +18,7 @@ void main() {
     final Store<AppState> store = testStoreFactory.initializeReduxStore(initialState: initialState);
 
     // When
-    await store.dispatch(RequestLogoutAction(LogoutRequester.USER));
+    await store.dispatch(RequestLogoutAction());
 
     // Then
     expect(testStoreFactory.poleEmploiTokenRepository.getPoleEmploiAccessToken(), isNull);

--- a/test/feature/login/post_logout_sign_out_from_firebase_test.dart
+++ b/test/feature/login/post_logout_sign_out_from_firebase_test.dart
@@ -15,7 +15,7 @@ void main() {
     final Store<AppState> store = testStoreFactory.initializeReduxStore(initialState: AppState.initialState());
 
     // When
-    await store.dispatch(RequestLogoutAction(LogoutRequester.USER));
+    await store.dispatch(RequestLogoutAction());
 
     // Then
     expect(firebaseAuthWrapperSpy.signOutHasBeenCalled, isTrue);


### PR DESCRIPTION
Je suis tombé dessus par hasard, cette notion est obsolète et faisait que le logout suite au retour 402 du backend ne fonctionnait pas.