### PR TITLE
Bugfix/ [US 936] Lorsqu'on filtre par "Débutant accepté" la pastille rouge n'apparait pas sur le bouton 'filtrer' de la page de résultat

### DIFF
--- a/lib/presentation/offre_emploi_search_results_view_model.dart
+++ b/lib/presentation/offre_emploi_search_results_view_model.dart
@@ -91,6 +91,7 @@ int _otherFiltresCount(OffreEmploiSearchParametersInitializedState searchParamsS
     searchParamsState.filtres.experience?.length ?? 0,
     searchParamsState.filtres.contrat?.length ?? 0,
     searchParamsState.filtres.duree?.length ?? 0,
+    searchParamsState.filtres.debutantOnly != null && searchParamsState.filtres.debutantOnly == true ? 1 : 0,
   ].fold(0, (previousValue, element) => previousValue + element);
 }
 

--- a/test/presentation/offre_emploi_search_results_view_model_test.dart
+++ b/test/presentation/offre_emploi_search_results_view_model_test.dart
@@ -222,22 +222,35 @@ void main() {
     });
 
     test(
-        "when state has multiple filtres active at the same time it should display the total count of active filtre as filtre number",
+        "when state has all active filtres at the same time it should display the total count of active filtre as filtre number",
         () {
       // Given
       final store = _storeWithFiltres(
         OffreEmploiSearchParametersFiltres.withFiltres(
-            distance: 40,
-            contrat: [ContratFiltre.cdi],
-            experience: [ExperienceFiltre.trois_ans_et_plus, ExperienceFiltre.de_un_a_trois_ans],
-            duree: [DureeFiltre.temps_plein]),
+          distance: 40,
+          debutantOnly: true,
+          contrat: [
+            ContratFiltre.cdi,
+            ContratFiltre.cdd_interim_saisonnier,
+            ContratFiltre.autre,
+          ],
+          experience: [
+            ExperienceFiltre.trois_ans_et_plus,
+            ExperienceFiltre.de_un_a_trois_ans,
+            ExperienceFiltre.de_zero_a_un_an,
+          ],
+          duree: [
+            DureeFiltre.temps_plein,
+            DureeFiltre.temps_partiel,
+          ],
+        ),
       );
 
       // When
       final viewModel = OffreEmploiSearchResultsViewModel.create(store);
 
       // Then
-      expect(viewModel.filtresCount, 5);
+      expect(viewModel.filtresCount, 10);
     });
   });
 


### PR DESCRIPTION
Trello => https://trello.com/c/ccyEfl8M/936-lorsquon-filtre-par-d%C3%A9butant-accept%C3%A9-la-pastille-rouge-napparait-pas-sur-le-bouton-filtrer-de-la-page-de-r%C3%A9sultat