### PR TITLE
chore(1253): Changement de lib matomo

### DIFF
--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -32,7 +32,7 @@ if (keystorePropertiesFile.exists()) {
 }
 
 android {
-    compileSdkVersion 31
+    compileSdkVersion 33
 
     sourceSets {
         main.java.srcDirs += 'src/main/kotlin'
@@ -50,7 +50,7 @@ android {
     defaultConfig {
         applicationId "fr.fabrique.social.gouv.passemploi"
         minSdkVersion 21
-        targetSdkVersion 31
+        targetSdkVersion 33
         versionCode flutterVersionCode.toInteger()
         versionName flutterVersionName
         manifestPlaceholders = [

--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -3,9 +3,6 @@
     package="fr.fabrique.social.gouv.pass_emploi_app">
 
     <uses-permission android:name="android.permission.INTERNET" />
-    <uses-permission
-        android:name="android.permission.REQUEST_INSTALL_PACKAGES"
-        tools:node="remove" />
 
     <application
         android:fullBackupContent="@xml/backup_rules"

--- a/lib/analytics/analytics_constants.dart
+++ b/lib/analytics/analytics_constants.dart
@@ -157,8 +157,8 @@ class AnalyticsActionNames {
 }
 
 class AnalyticsCustomDimensions {
-  static const userTypeId = 1;
-  static const structureId = 2;
+  static const userTypeId = '1';
+  static const structureId = '2';
 
   static const appUserType = "jeune";
 }

--- a/lib/analytics/tracker.dart
+++ b/lib/analytics/tracker.dart
@@ -1,5 +1,5 @@
 import 'package:flutter/material.dart';
-import 'package:matomo/matomo.dart';
+import 'package:matomo_tracker/matomo_tracker.dart';
 import 'package:pass_emploi_app/pass_emploi_app.dart';
 
 class Tracker extends StatefulWidget {
@@ -45,6 +45,6 @@ class _TrackerState extends State<Tracker> with RouteAware {
   }
 
   void _track() {
-    MatomoTracker.trackScreenWithName(widget.tracking, 'WidgetCreated');
+    MatomoTracker.instance.trackScreen(context, eventName: widget.tracking);
   }
 }

--- a/lib/analytics/tracker.dart
+++ b/lib/analytics/tracker.dart
@@ -1,6 +1,6 @@
 import 'package:flutter/material.dart';
-import 'package:matomo_tracker/matomo_tracker.dart';
 import 'package:pass_emploi_app/pass_emploi_app.dart';
+import 'package:pass_emploi_app/utils/pass_emploi_matomo_tracker.dart';
 
 class Tracker extends StatefulWidget {
   final String tracking;
@@ -45,6 +45,6 @@ class _TrackerState extends State<Tracker> with RouteAware {
   }
 
   void _track() {
-    MatomoTracker.instance.trackScreen(context, eventName: widget.tracking);
+    PassEmploiMatomoTracker.instance.trackScreen(context, eventName: widget.tracking);
   }
 }

--- a/lib/app_initializer.dart
+++ b/lib/app_initializer.dart
@@ -12,7 +12,7 @@ import 'package:flutter_secure_storage/flutter_secure_storage.dart';
 import 'package:http/http.dart';
 import 'package:http/io_client.dart';
 import 'package:http_interceptor/http/intercepted_client.dart';
-import 'package:matomo/matomo.dart';
+import 'package:matomo_tracker/matomo_tracker.dart';
 import 'package:package_info/package_info.dart';
 import 'package:pass_emploi_app/analytics/analytics_constants.dart';
 import 'package:pass_emploi_app/auth/auth_access_checker.dart';
@@ -105,8 +105,10 @@ class AppInitializer {
   Future<void> _initializeMatomoTracker(Configuration configuration) async {
     final siteId = configuration.matomoSiteId;
     final url = configuration.matomoBaseUrl;
-    await MatomoTracker().initialize(siteId: int.parse(siteId), url: url);
-    MatomoTracker.setCustomDimension(AnalyticsCustomDimensions.userTypeId, AnalyticsCustomDimensions.appUserType);
+    await MatomoTracker.instance.initialize(siteId: int.parse(siteId), url: url);
+    MatomoTracker.instance.trackDimensions({
+      AnalyticsCustomDimensions.userTypeId: AnalyticsCustomDimensions.appUserType,
+    });
   }
 
   Future<FirebaseRemoteConfig?> _remoteConfig() async {
@@ -212,7 +214,7 @@ class AppInitializer {
       SuppressionCompteRepository(baseUrl, httpClient, crashlytics),
       modeDemoRepository,
       CampagneRepository(baseUrl, httpClient, crashlytics),
-      MatomoTracker(),
+      MatomoTracker.instance,
       UpdateDemarcheRepository(baseUrl, httpClient, crashlytics),
       CreateDemarcheRepository(baseUrl, httpClient, crashlytics),
       SearchDemarcheRepository(baseUrl, httpClient, crashlytics),

--- a/lib/app_initializer.dart
+++ b/lib/app_initializer.dart
@@ -12,7 +12,6 @@ import 'package:flutter_secure_storage/flutter_secure_storage.dart';
 import 'package:http/http.dart';
 import 'package:http/io_client.dart';
 import 'package:http_interceptor/http/intercepted_client.dart';
-import 'package:matomo_tracker/matomo_tracker.dart';
 import 'package:package_info/package_info.dart';
 import 'package:pass_emploi_app/analytics/analytics_constants.dart';
 import 'package:pass_emploi_app/auth/auth_access_checker.dart';
@@ -76,6 +75,7 @@ import 'package:pass_emploi_app/repositories/suggestions_recherche_repository.da
 import 'package:pass_emploi_app/repositories/suppression_compte_repository.dart';
 import 'package:pass_emploi_app/repositories/tracking_analytics/tracking_event_repository.dart';
 import 'package:pass_emploi_app/repositories/tutorial_repository.dart';
+import 'package:pass_emploi_app/utils/pass_emploi_matomo_tracker.dart';
 /*AUTOGENERATE-REDUX-APP-INITIALIZER-REPOSITORY-IMPORT*/
 import 'package:pass_emploi_app/utils/secure_storage_exception_handler_decorator.dart';
 import 'package:redux/redux.dart';
@@ -105,8 +105,8 @@ class AppInitializer {
   Future<void> _initializeMatomoTracker(Configuration configuration) async {
     final siteId = configuration.matomoSiteId;
     final url = configuration.matomoBaseUrl;
-    await MatomoTracker.instance.initialize(siteId: int.parse(siteId), url: url);
-    MatomoTracker.instance.trackDimensions({
+    await PassEmploiMatomoTracker.instance.initialize(siteId: int.parse(siteId), url: url);
+    PassEmploiMatomoTracker.instance.trackDimensions({
       AnalyticsCustomDimensions.userTypeId: AnalyticsCustomDimensions.appUserType,
     });
   }
@@ -214,7 +214,7 @@ class AppInitializer {
       SuppressionCompteRepository(baseUrl, httpClient, crashlytics),
       modeDemoRepository,
       CampagneRepository(baseUrl, httpClient, crashlytics),
-      MatomoTracker.instance,
+      PassEmploiMatomoTracker.instance,
       UpdateDemarcheRepository(baseUrl, httpClient, crashlytics),
       CreateDemarcheRepository(baseUrl, httpClient, crashlytics),
       SearchDemarcheRepository(baseUrl, httpClient, crashlytics),

--- a/lib/features/developer_option/matomo/matomo_logging_middleware.dart
+++ b/lib/features/developer_option/matomo/matomo_logging_middleware.dart
@@ -1,49 +1,21 @@
-import 'dart:async';
-
-import 'package:matomo_tracker/matomo_tracker.dart';
 import 'package:pass_emploi_app/configuration/configuration.dart';
 import 'package:pass_emploi_app/features/bootstrap/bootstrap_action.dart';
 import 'package:pass_emploi_app/features/developer_option/matomo/matomo_logging_action.dart';
 import 'package:pass_emploi_app/redux/app_state.dart';
+import 'package:pass_emploi_app/utils/pass_emploi_matomo_tracker.dart';
 import 'package:redux/redux.dart';
 
 class MatomoLoggingMiddleware extends MiddlewareClass<AppState> {
-  StreamSubscription<LogRecord>? _subscription;
-
   @override
   void call(Store<AppState> store, dynamic action, NextDispatcher next) async {
     next(action);
     if (_shouldActivateMatomoLogging(store, action)) {
-      _enableMatomoLogger();
-      _subscribeToMatomoLogger(store);
+      PassEmploiMatomoTracker.instance.onTrackScreen = (screen) => store.dispatch(MatomoLoggingAction(screen));
     }
   }
 
   bool _shouldActivateMatomoLogging(Store<AppState> store, dynamic action) {
     final flavor = store.state.configurationState.getFlavor();
-    return flavor == Flavor.STAGING && action is BootstrapAction && _subscription == null;
-  }
-
-  void _enableMatomoLogger() {
-    hierarchicalLoggingEnabled = true;
-    MatomoTracker.instance.log.level = Level.ALL;
-  }
-
-  void _subscribeToMatomoLogger(Store<AppState> store) {
-    MatomoTracker.instance.log._subscription = MatomoTracker.instance.log.onRecord.listen((event) {
-      final trackingEvent = _getEventFromMessage(event.message);
-      if (trackingEvent != null) store.dispatch(MatomoLoggingAction(trackingEvent));
-    });
-  }
-
-  String? _getEventFromMessage(String message) {
-    if (message.startsWith(' -> ')) {
-      final url = message.replaceFirst(' -> ', '');
-      try {
-        final uri = Uri.parse(url);
-        return uri.queryParameters['action_name'];
-      } catch (_) {}
-    }
-    return null;
+    return flavor == Flavor.STAGING && action is BootstrapAction;
   }
 }

--- a/lib/features/developer_option/matomo/matomo_logging_middleware.dart
+++ b/lib/features/developer_option/matomo/matomo_logging_middleware.dart
@@ -1,7 +1,6 @@
 import 'dart:async';
 
-import 'package:logging/logging.dart';
-import 'package:matomo/matomo.dart';
+import 'package:matomo_tracker/matomo_tracker.dart';
 import 'package:pass_emploi_app/configuration/configuration.dart';
 import 'package:pass_emploi_app/features/bootstrap/bootstrap_action.dart';
 import 'package:pass_emploi_app/features/developer_option/matomo/matomo_logging_action.dart';
@@ -27,11 +26,11 @@ class MatomoLoggingMiddleware extends MiddlewareClass<AppState> {
 
   void _enableMatomoLogger() {
     hierarchicalLoggingEnabled = true;
-    MatomoTracker().log.level = Level.ALL;
+    MatomoTracker.instance.log.level = Level.ALL;
   }
 
   void _subscribeToMatomoLogger(Store<AppState> store) {
-    _subscription = MatomoTracker().log.onRecord.listen((event) {
+    MatomoTracker.instance.log._subscription = MatomoTracker.instance.log.onRecord.listen((event) {
       final trackingEvent = _getEventFromMessage(event.message);
       if (trackingEvent != null) store.dispatch(MatomoLoggingAction(trackingEvent));
     });

--- a/lib/features/login/login_middleware.dart
+++ b/lib/features/login/login_middleware.dart
@@ -1,4 +1,3 @@
-import 'package:matomo_tracker/matomo_tracker.dart';
 import 'package:pass_emploi_app/auth/auth_id_token.dart';
 import 'package:pass_emploi_app/auth/authenticator.dart';
 import 'package:pass_emploi_app/auth/firebase_auth_wrapper.dart';
@@ -8,13 +7,14 @@ import 'package:pass_emploi_app/features/login/login_actions.dart';
 import 'package:pass_emploi_app/features/mode_demo/is_mode_demo_repository.dart';
 import 'package:pass_emploi_app/models/user.dart';
 import 'package:pass_emploi_app/redux/app_state.dart';
+import 'package:pass_emploi_app/utils/pass_emploi_matomo_tracker.dart';
 import 'package:redux/redux.dart';
 
 class LoginMiddleware extends MiddlewareClass<AppState> {
   final Authenticator _authenticator;
   final FirebaseAuthWrapper _firebaseAuthWrapper;
   final ModeDemoRepository _modeDemoRepository;
-  final MatomoTracker _matomoTracker;
+  final PassEmploiMatomoTracker _matomoTracker;
 
   LoginMiddleware(this._authenticator, this._firebaseAuthWrapper, this._modeDemoRepository, this._matomoTracker);
 

--- a/lib/features/login/login_middleware.dart
+++ b/lib/features/login/login_middleware.dart
@@ -1,4 +1,4 @@
-import 'package:matomo/matomo.dart';
+import 'package:matomo_tracker/matomo_tracker.dart';
 import 'package:pass_emploi_app/auth/auth_id_token.dart';
 import 'package:pass_emploi_app/auth/authenticator.dart';
 import 'package:pass_emploi_app/auth/firebase_auth_wrapper.dart';
@@ -44,9 +44,9 @@ class LoginMiddleware extends MiddlewareClass<AppState> {
       _modeDemoRepository.setModeDemo(true);
       final user = _modeDemoUser(mode);
       store.dispatch(LoginSuccessAction(user));
-      _matomoTracker.setOptOut(true);
+      _matomoTracker.setOptOut(optout: true);
     } else {
-      _matomoTracker.setOptOut(false);
+      _matomoTracker.setOptOut(optout: false);
       _modeDemoRepository.setModeDemo(false);
       final authenticatorResponse = await _authenticator.login(_getAuthenticationMode(mode));
       if (authenticatorResponse == AuthenticatorResponse.SUCCESS) {
@@ -82,7 +82,7 @@ class LoginMiddleware extends MiddlewareClass<AppState> {
   }
 
   void _logout(Store<AppState> store) async {
-    _matomoTracker.setOptOut(false);
+    _matomoTracker.setOptOut(optout: false);
     await _authenticator.logout();
     store.dispatch(UnsubscribeFromChatStatusAction());
     store.dispatch(BootstrapAction());

--- a/lib/features/tracking/user_tracking_structure_middleware.dart
+++ b/lib/features/tracking/user_tracking_structure_middleware.dart
@@ -1,4 +1,4 @@
-import 'package:matomo/matomo.dart';
+import 'package:matomo_tracker/matomo_tracker.dart';
 import 'package:pass_emploi_app/analytics/analytics_constants.dart';
 import 'package:pass_emploi_app/auth/auth_id_token.dart';
 import 'package:pass_emploi_app/features/login/login_actions.dart';
@@ -11,7 +11,10 @@ class UserTrackingStructureMiddleware extends MiddlewareClass<AppState> {
     next(action);
     if (action is LoginSuccessAction) {
       final structureName = _getStructureName(action.user.loginMode);
-      MatomoTracker.setCustomDimension(AnalyticsCustomDimensions.structureId, structureName);
+      MatomoTracker.instance.trackDimensions({
+        AnalyticsCustomDimensions.userTypeId: AnalyticsCustomDimensions.appUserType,
+        AnalyticsCustomDimensions.structureId: structureName,
+      });
     }
   }
 

--- a/lib/features/tracking/user_tracking_structure_middleware.dart
+++ b/lib/features/tracking/user_tracking_structure_middleware.dart
@@ -1,8 +1,8 @@
-import 'package:matomo_tracker/matomo_tracker.dart';
 import 'package:pass_emploi_app/analytics/analytics_constants.dart';
 import 'package:pass_emploi_app/auth/auth_id_token.dart';
 import 'package:pass_emploi_app/features/login/login_actions.dart';
 import 'package:pass_emploi_app/redux/app_state.dart';
+import 'package:pass_emploi_app/utils/pass_emploi_matomo_tracker.dart';
 import 'package:redux/redux.dart';
 
 class UserTrackingStructureMiddleware extends MiddlewareClass<AppState> {
@@ -11,7 +11,7 @@ class UserTrackingStructureMiddleware extends MiddlewareClass<AppState> {
     next(action);
     if (action is LoginSuccessAction) {
       final structureName = _getStructureName(action.user.loginMode);
-      MatomoTracker.instance.trackDimensions({
+      PassEmploiMatomoTracker.instance.trackDimensions({
         AnalyticsCustomDimensions.userTypeId: AnalyticsCustomDimensions.appUserType,
         AnalyticsCustomDimensions.structureId: structureName,
       });

--- a/lib/pages/cej_information_page.dart
+++ b/lib/pages/cej_information_page.dart
@@ -1,6 +1,5 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_svg/svg.dart';
-import 'package:matomo_tracker/matomo_tracker.dart';
 import 'package:pass_emploi_app/analytics/analytics_constants.dart';
 import 'package:pass_emploi_app/pages/choix_organisme_page.dart';
 import 'package:pass_emploi_app/ui/app_colors.dart';
@@ -8,6 +7,7 @@ import 'package:pass_emploi_app/ui/drawables.dart';
 import 'package:pass_emploi_app/ui/margins.dart';
 import 'package:pass_emploi_app/ui/strings.dart';
 import 'package:pass_emploi_app/ui/text_styles.dart';
+import 'package:pass_emploi_app/utils/pass_emploi_matomo_tracker.dart';
 import 'package:pass_emploi_app/widgets/buttons/primary_action_button.dart';
 import 'package:pass_emploi_app/widgets/cej_information_content_card.dart';
 import 'package:pass_emploi_app/widgets/primary_rounded_bottom_background.dart';
@@ -32,7 +32,7 @@ class _CejInformationPageState extends State<CejInformationPage> {
       final _controllerPage = _controller.page?.floor();
       if (_controllerPage != null && _controllerPage != _displayedPage) {
         _displayedPage = _controllerPage;
-        MatomoTracker.instance.trackScreen(
+        PassEmploiMatomoTracker.instance.trackScreen(
           context,
           eventName: AnalyticsScreenNames.cejInformationPage(_controllerPage + 1),
         );

--- a/lib/pages/cej_information_page.dart
+++ b/lib/pages/cej_information_page.dart
@@ -1,6 +1,6 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_svg/svg.dart';
-import 'package:matomo/matomo.dart';
+import 'package:matomo_tracker/matomo_tracker.dart';
 import 'package:pass_emploi_app/analytics/analytics_constants.dart';
 import 'package:pass_emploi_app/pages/choix_organisme_page.dart';
 import 'package:pass_emploi_app/ui/app_colors.dart';
@@ -32,7 +32,10 @@ class _CejInformationPageState extends State<CejInformationPage> {
       final _controllerPage = _controller.page?.floor();
       if (_controllerPage != null && _controllerPage != _displayedPage) {
         _displayedPage = _controllerPage;
-        MatomoTracker.trackScreenWithName(AnalyticsScreenNames.cejInformationPage(_controllerPage + 1), "");
+        MatomoTracker.instance.trackScreen(
+          context,
+          eventName: AnalyticsScreenNames.cejInformationPage(_controllerPage + 1),
+        );
       }
     });
     super.initState();

--- a/lib/pages/chat_partage_page.dart
+++ b/lib/pages/chat_partage_page.dart
@@ -1,6 +1,5 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_redux/flutter_redux.dart';
-import 'package:matomo_tracker/matomo_tracker.dart';
 import 'package:pass_emploi_app/analytics/analytics_constants.dart';
 import 'package:pass_emploi_app/analytics/tracker.dart';
 import 'package:pass_emploi_app/presentation/chat_partage_page_view_model.dart';
@@ -10,6 +9,7 @@ import 'package:pass_emploi_app/ui/app_colors.dart';
 import 'package:pass_emploi_app/ui/margins.dart';
 import 'package:pass_emploi_app/ui/strings.dart';
 import 'package:pass_emploi_app/ui/text_styles.dart';
+import 'package:pass_emploi_app/utils/pass_emploi_matomo_tracker.dart';
 import 'package:pass_emploi_app/widgets/buttons/primary_action_button.dart';
 import 'package:pass_emploi_app/widgets/default_app_bar.dart';
 import 'package:pass_emploi_app/widgets/snack_bar/show_snack_bar.dart';
@@ -151,7 +151,7 @@ class _ChatPartagePageState extends State<ChatPartagePage> {
       case DisplayState.LOADING:
         return;
       case DisplayState.CONTENT:
-        MatomoTracker.instance.trackScreen(context, eventName: viewModel.snackbarSuccessTracking);
+        PassEmploiMatomoTracker.instance.trackScreen(context, eventName: viewModel.snackbarSuccessTracking);
         showSuccessfulSnackBar(context, viewModel.snackbarSuccessText);
         viewModel.snackbarDisplayed();
         Navigator.pop(context);

--- a/lib/pages/chat_partage_page.dart
+++ b/lib/pages/chat_partage_page.dart
@@ -1,6 +1,6 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_redux/flutter_redux.dart';
-import 'package:matomo/matomo.dart';
+import 'package:matomo_tracker/matomo_tracker.dart';
 import 'package:pass_emploi_app/analytics/analytics_constants.dart';
 import 'package:pass_emploi_app/analytics/tracker.dart';
 import 'package:pass_emploi_app/presentation/chat_partage_page_view_model.dart';
@@ -151,7 +151,7 @@ class _ChatPartagePageState extends State<ChatPartagePage> {
       case DisplayState.LOADING:
         return;
       case DisplayState.CONTENT:
-        MatomoTracker.trackScreenWithName(viewModel.snackbarSuccessTracking, "");
+        MatomoTracker.instance.trackScreen(context, eventName: viewModel.snackbarSuccessTracking);
         showSuccessfulSnackBar(context, viewModel.snackbarSuccessText);
         viewModel.snackbarDisplayed();
         Navigator.pop(context);

--- a/lib/pages/choix_organisme_page.dart
+++ b/lib/pages/choix_organisme_page.dart
@@ -1,6 +1,5 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_svg/svg.dart';
-import 'package:matomo_tracker/matomo_tracker.dart';
 import 'package:pass_emploi_app/analytics/analytics_constants.dart';
 import 'package:pass_emploi_app/analytics/tracker.dart';
 import 'package:pass_emploi_app/pages/choix_organisme_explaination_page.dart';
@@ -11,6 +10,7 @@ import 'package:pass_emploi_app/ui/margins.dart';
 import 'package:pass_emploi_app/ui/strings.dart';
 import 'package:pass_emploi_app/ui/text_styles.dart';
 import 'package:pass_emploi_app/utils/launcher_utils.dart';
+import 'package:pass_emploi_app/utils/pass_emploi_matomo_tracker.dart';
 import 'package:pass_emploi_app/widgets/buttons/primary_action_button.dart';
 import 'package:pass_emploi_app/widgets/primary_rounded_bottom_background.dart';
 
@@ -93,7 +93,7 @@ class ChoixOrganismePage extends StatelessWidget {
                             color: Colors.transparent,
                             child: InkWell(
                               onTap: () {
-                                MatomoTracker.instance.trackOutlink(noOrganismeLink);
+                                PassEmploiMatomoTracker.instance.trackOutlink(noOrganismeLink);
                                 launchExternalUrl(noOrganismeLink);
                               },
                               child: Padding(

--- a/lib/pages/choix_organisme_page.dart
+++ b/lib/pages/choix_organisme_page.dart
@@ -1,6 +1,6 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_svg/svg.dart';
-import 'package:matomo/matomo.dart';
+import 'package:matomo_tracker/matomo_tracker.dart';
 import 'package:pass_emploi_app/analytics/analytics_constants.dart';
 import 'package:pass_emploi_app/analytics/tracker.dart';
 import 'package:pass_emploi_app/pages/choix_organisme_explaination_page.dart';
@@ -93,7 +93,7 @@ class ChoixOrganismePage extends StatelessWidget {
                             color: Colors.transparent,
                             child: InkWell(
                               onTap: () {
-                                MatomoTracker.trackOutlink(noOrganismeLink);
+                                MatomoTracker.instance.trackOutlink(noOrganismeLink);
                                 launchExternalUrl(noOrganismeLink);
                               },
                               child: Padding(

--- a/lib/pages/demarche/create_demarche_step3_page.dart
+++ b/lib/pages/demarche/create_demarche_step3_page.dart
@@ -1,6 +1,5 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_redux/flutter_redux.dart';
-import 'package:matomo_tracker/matomo_tracker.dart';
 import 'package:pass_emploi_app/analytics/analytics_constants.dart';
 import 'package:pass_emploi_app/analytics/tracker.dart';
 import 'package:pass_emploi_app/features/demarche/create/create_demarche_actions.dart';
@@ -12,6 +11,7 @@ import 'package:pass_emploi_app/ui/font_sizes.dart';
 import 'package:pass_emploi_app/ui/margins.dart';
 import 'package:pass_emploi_app/ui/strings.dart';
 import 'package:pass_emploi_app/ui/text_styles.dart';
+import 'package:pass_emploi_app/utils/pass_emploi_matomo_tracker.dart';
 import 'package:pass_emploi_app/widgets/buttons/primary_action_button.dart';
 import 'package:pass_emploi_app/widgets/date_pickers/date_picker.dart';
 import 'package:pass_emploi_app/widgets/default_app_bar.dart';
@@ -104,7 +104,7 @@ class _CreateDemarcheStep3PageState extends State<CreateDemarcheStep3Page> {
   void _onDidChange(CreateDemarcheStep3ViewModel? oldVm, CreateDemarcheStep3ViewModel newVm) {
     if (newVm.shouldGoBack) {
       Navigator.popUntil(context, (route) => route.settings.name == Navigator.defaultRouteName);
-      MatomoTracker.instance.trackScreen(context, eventName: AnalyticsScreenNames.searchDemarcheStep3Success);
+      PassEmploiMatomoTracker.instance.trackScreen(context, eventName: AnalyticsScreenNames.searchDemarcheStep3Success);
       showSuccessfulSnackBar(context, Strings.demarcheCreationSuccess);
     }
   }

--- a/lib/pages/demarche/create_demarche_step3_page.dart
+++ b/lib/pages/demarche/create_demarche_step3_page.dart
@@ -1,6 +1,6 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_redux/flutter_redux.dart';
-import 'package:matomo/matomo.dart';
+import 'package:matomo_tracker/matomo_tracker.dart';
 import 'package:pass_emploi_app/analytics/analytics_constants.dart';
 import 'package:pass_emploi_app/analytics/tracker.dart';
 import 'package:pass_emploi_app/features/demarche/create/create_demarche_actions.dart';
@@ -104,7 +104,7 @@ class _CreateDemarcheStep3PageState extends State<CreateDemarcheStep3Page> {
   void _onDidChange(CreateDemarcheStep3ViewModel? oldVm, CreateDemarcheStep3ViewModel newVm) {
     if (newVm.shouldGoBack) {
       Navigator.popUntil(context, (route) => route.settings.name == Navigator.defaultRouteName);
-      MatomoTracker.trackScreenWithName(AnalyticsScreenNames.searchDemarcheStep3Success, '');
+      MatomoTracker.instance.trackScreen(context, eventName: AnalyticsScreenNames.searchDemarcheStep3Success);
       showSuccessfulSnackBar(context, Strings.demarcheCreationSuccess);
     }
   }

--- a/lib/pages/entree_page.dart
+++ b/lib/pages/entree_page.dart
@@ -1,6 +1,5 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_svg/svg.dart';
-import 'package:matomo_tracker/matomo_tracker.dart';
 import 'package:pass_emploi_app/analytics/analytics_constants.dart';
 import 'package:pass_emploi_app/analytics/tracker.dart';
 import 'package:pass_emploi_app/features/mode_demo/explication_page_mode_demo.dart';
@@ -13,6 +12,7 @@ import 'package:pass_emploi_app/ui/shadows.dart';
 import 'package:pass_emploi_app/ui/strings.dart';
 import 'package:pass_emploi_app/ui/text_styles.dart';
 import 'package:pass_emploi_app/utils/launcher_utils.dart';
+import 'package:pass_emploi_app/utils/pass_emploi_matomo_tracker.dart';
 import 'package:pass_emploi_app/widgets/buttons/primary_action_button.dart';
 import 'package:pass_emploi_app/widgets/buttons/secondary_button.dart';
 import 'package:pass_emploi_app/widgets/entree_biseau_background.dart';
@@ -148,7 +148,7 @@ class Link extends StatelessWidget {
       color: Colors.transparent,
       child: InkWell(
         onTap: () {
-          MatomoTracker.instance.trackOutlink(link);
+          PassEmploiMatomoTracker.instance.trackOutlink(link);
           launchExternalUrl(link);
         },
         child: Wrap(

--- a/lib/pages/entree_page.dart
+++ b/lib/pages/entree_page.dart
@@ -1,6 +1,6 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_svg/svg.dart';
-import 'package:matomo/matomo.dart';
+import 'package:matomo_tracker/matomo_tracker.dart';
 import 'package:pass_emploi_app/analytics/analytics_constants.dart';
 import 'package:pass_emploi_app/analytics/tracker.dart';
 import 'package:pass_emploi_app/features/mode_demo/explication_page_mode_demo.dart';
@@ -148,7 +148,7 @@ class Link extends StatelessWidget {
       color: Colors.transparent,
       child: InkWell(
         onTap: () {
-          MatomoTracker.trackOutlink(link);
+          MatomoTracker.instance.trackOutlink(link);
           launchExternalUrl(link);
         },
         child: Wrap(

--- a/lib/pages/immersion_list_page.dart
+++ b/lib/pages/immersion_list_page.dart
@@ -1,6 +1,5 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_redux/flutter_redux.dart';
-import 'package:matomo_tracker/matomo_tracker.dart';
 import 'package:pass_emploi_app/analytics/analytics_constants.dart';
 import 'package:pass_emploi_app/analytics/tracker.dart';
 import 'package:pass_emploi_app/models/immersion.dart';
@@ -15,6 +14,7 @@ import 'package:pass_emploi_app/ui/drawables.dart';
 import 'package:pass_emploi_app/ui/margins.dart';
 import 'package:pass_emploi_app/ui/strings.dart';
 import 'package:pass_emploi_app/ui/text_styles.dart';
+import 'package:pass_emploi_app/utils/pass_emploi_matomo_tracker.dart';
 import 'package:pass_emploi_app/widgets/bottom_sheets/bottom_sheets.dart';
 import 'package:pass_emploi_app/widgets/bottom_sheets/immersion_saved_search_bottom_sheet.dart';
 import 'package:pass_emploi_app/widgets/buttons/filtre_button.dart';
@@ -187,6 +187,6 @@ class ImmersionListPage extends StatelessWidget {
   }
 
   void _trackEmptyResult(BuildContext context) {
-    MatomoTracker.instance.trackScreen(context, eventName: AnalyticsScreenNames.immersionNoResults);
+    PassEmploiMatomoTracker.instance.trackScreen(context, eventName: AnalyticsScreenNames.immersionNoResults);
   }
 }

--- a/lib/pages/immersion_list_page.dart
+++ b/lib/pages/immersion_list_page.dart
@@ -1,6 +1,6 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_redux/flutter_redux.dart';
-import 'package:matomo/matomo.dart';
+import 'package:matomo_tracker/matomo_tracker.dart';
 import 'package:pass_emploi_app/analytics/analytics_constants.dart';
 import 'package:pass_emploi_app/analytics/tracker.dart';
 import 'package:pass_emploi_app/models/immersion.dart';
@@ -62,7 +62,7 @@ class ImmersionListPage extends StatelessWidget {
   }
 
   Widget _empty(BuildContext context, ImmersionSearchResultsViewModel viewModel) {
-    _trackEmptyResult();
+    _trackEmptyResult(context);
     return EmptyOffreWidget(
       withModifyButton: !fromSavedSearch,
       additional: Padding(
@@ -186,7 +186,7 @@ class ImmersionListPage extends StatelessWidget {
     );
   }
 
-  void _trackEmptyResult() {
-    MatomoTracker.trackScreenWithName(AnalyticsScreenNames.immersionNoResults, "");
+  void _trackEmptyResult(BuildContext context) {
+    MatomoTracker.instance.trackScreen(context, eventName: AnalyticsScreenNames.immersionNoResults);
   }
 }

--- a/lib/pages/offre_emploi_list_page.dart
+++ b/lib/pages/offre_emploi_list_page.dart
@@ -1,6 +1,5 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_redux/flutter_redux.dart';
-import 'package:matomo_tracker/matomo_tracker.dart';
 import 'package:pass_emploi_app/analytics/analytics_constants.dart';
 import 'package:pass_emploi_app/analytics/tracker.dart';
 import 'package:pass_emploi_app/features/offre_emploi/search/offre_emploi_search_actions.dart';
@@ -17,6 +16,7 @@ import 'package:pass_emploi_app/ui/drawables.dart';
 import 'package:pass_emploi_app/ui/margins.dart';
 import 'package:pass_emploi_app/ui/strings.dart';
 import 'package:pass_emploi_app/ui/text_styles.dart';
+import 'package:pass_emploi_app/utils/pass_emploi_matomo_tracker.dart';
 import 'package:pass_emploi_app/widgets/bottom_sheets/bottom_sheets.dart';
 import 'package:pass_emploi_app/widgets/bottom_sheets/offre_emploi_saved_search_bottom_sheet.dart';
 import 'package:pass_emploi_app/widgets/buttons/filtre_button.dart';
@@ -281,7 +281,7 @@ class _OffreEmploiListPageState extends State<OffreEmploiListPage> {
   }
 
   void _trackEmptyResult() {
-    MatomoTracker.instance.trackScreenWithName(
+    PassEmploiMatomoTracker.instance.trackScreenWithName(
       widgetName: widget.onlyAlternance ? AnalyticsScreenNames.alternanceResearch : AnalyticsScreenNames.emploiResearch,
       eventName:
           widget.onlyAlternance ? AnalyticsScreenNames.alternanceNoResults : AnalyticsScreenNames.emploiNoResults,

--- a/lib/pages/offre_emploi_list_page.dart
+++ b/lib/pages/offre_emploi_list_page.dart
@@ -1,6 +1,6 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_redux/flutter_redux.dart';
-import 'package:matomo/matomo.dart';
+import 'package:matomo_tracker/matomo_tracker.dart';
 import 'package:pass_emploi_app/analytics/analytics_constants.dart';
 import 'package:pass_emploi_app/analytics/tracker.dart';
 import 'package:pass_emploi_app/features/offre_emploi/search/offre_emploi_search_actions.dart';
@@ -281,9 +281,10 @@ class _OffreEmploiListPageState extends State<OffreEmploiListPage> {
   }
 
   void _trackEmptyResult() {
-    MatomoTracker.trackScreenWithName(
-      widget.onlyAlternance ? AnalyticsScreenNames.alternanceNoResults : AnalyticsScreenNames.emploiNoResults,
-      widget.onlyAlternance ? AnalyticsScreenNames.alternanceResearch : AnalyticsScreenNames.emploiResearch,
+    MatomoTracker.instance.trackScreenWithName(
+      widgetName: widget.onlyAlternance ? AnalyticsScreenNames.alternanceResearch : AnalyticsScreenNames.emploiResearch,
+      eventName:
+          widget.onlyAlternance ? AnalyticsScreenNames.alternanceNoResults : AnalyticsScreenNames.emploiNoResults,
     );
   }
 

--- a/lib/pages/profil/profil_page.dart
+++ b/lib/pages/profil/profil_page.dart
@@ -1,7 +1,6 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_redux/flutter_redux.dart';
 import 'package:flutter_svg/flutter_svg.dart';
-import 'package:matomo_tracker/matomo_tracker.dart';
 import 'package:pass_emploi_app/analytics/analytics_constants.dart';
 import 'package:pass_emploi_app/analytics/tracker.dart';
 import 'package:pass_emploi_app/features/details_jeune/details_jeune_actions.dart';
@@ -17,6 +16,7 @@ import 'package:pass_emploi_app/ui/margins.dart';
 import 'package:pass_emploi_app/ui/strings.dart';
 import 'package:pass_emploi_app/ui/text_styles.dart';
 import 'package:pass_emploi_app/utils/launcher_utils.dart';
+import 'package:pass_emploi_app/utils/pass_emploi_matomo_tracker.dart';
 import 'package:pass_emploi_app/widgets/bottom_sheets/bottom_sheets.dart';
 import 'package:pass_emploi_app/widgets/bottom_sheets/rating_bottom_sheet.dart';
 import 'package:pass_emploi_app/widgets/buttons/secondary_button.dart';
@@ -223,7 +223,7 @@ class _LegalInformationCard extends StatelessWidget {
   }
 
   void _launchAndTrackExternalLink(String link) {
-    MatomoTracker.instance.trackOutlink(link);
+    PassEmploiMatomoTracker.instance.trackOutlink(link);
     launchExternalUrl(link);
   }
 

--- a/lib/pages/profil/profil_page.dart
+++ b/lib/pages/profil/profil_page.dart
@@ -1,7 +1,7 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_redux/flutter_redux.dart';
 import 'package:flutter_svg/flutter_svg.dart';
-import 'package:matomo/matomo.dart';
+import 'package:matomo_tracker/matomo_tracker.dart';
 import 'package:pass_emploi_app/analytics/analytics_constants.dart';
 import 'package:pass_emploi_app/analytics/tracker.dart';
 import 'package:pass_emploi_app/features/details_jeune/details_jeune_actions.dart';
@@ -223,7 +223,7 @@ class _LegalInformationCard extends StatelessWidget {
   }
 
   void _launchAndTrackExternalLink(String link) {
-    MatomoTracker.trackOutlink(link);
+    MatomoTracker.instance.trackOutlink(link);
     launchExternalUrl(link);
   }
 

--- a/lib/pages/rendezvous/rendezvous_details_page.dart
+++ b/lib/pages/rendezvous/rendezvous_details_page.dart
@@ -3,7 +3,7 @@ import 'dart:io' as io;
 import 'package:flutter/material.dart';
 import 'package:flutter_redux/flutter_redux.dart';
 import 'package:flutter_svg/svg.dart';
-import 'package:matomo/matomo.dart';
+import 'package:matomo_tracker/matomo_tracker.dart';
 import 'package:pass_emploi_app/features/rendezvous/details/rendezvous_details_actions.dart';
 import 'package:pass_emploi_app/pages/chat_partage_page.dart';
 import 'package:pass_emploi_app/presentation/chat_partage_page_view_model.dart';
@@ -86,7 +86,9 @@ class RendezvousDetailsPage extends StatelessWidget {
   }
 
   Widget _content(BuildContext context, RendezvousDetailsViewModel viewModel) {
-    if (viewModel.trackingPageName != null) MatomoTracker.trackScreenWithName(viewModel.trackingPageName!, '');
+    if (viewModel.trackingPageName != null) {
+      MatomoTracker.instance.trackScreen(context, eventName: viewModel.trackingPageName!);
+    }
     return SingleChildScrollView(
       child: Padding(
         padding: const EdgeInsets.all(Margins.spacing_base),

--- a/lib/pages/rendezvous/rendezvous_details_page.dart
+++ b/lib/pages/rendezvous/rendezvous_details_page.dart
@@ -3,7 +3,6 @@ import 'dart:io' as io;
 import 'package:flutter/material.dart';
 import 'package:flutter_redux/flutter_redux.dart';
 import 'package:flutter_svg/svg.dart';
-import 'package:matomo_tracker/matomo_tracker.dart';
 import 'package:pass_emploi_app/features/rendezvous/details/rendezvous_details_actions.dart';
 import 'package:pass_emploi_app/pages/chat_partage_page.dart';
 import 'package:pass_emploi_app/presentation/chat_partage_page_view_model.dart';
@@ -17,6 +16,7 @@ import 'package:pass_emploi_app/ui/margins.dart';
 import 'package:pass_emploi_app/ui/strings.dart';
 import 'package:pass_emploi_app/ui/text_styles.dart';
 import 'package:pass_emploi_app/utils/launcher_utils.dart';
+import 'package:pass_emploi_app/utils/pass_emploi_matomo_tracker.dart';
 import 'package:pass_emploi_app/utils/platform.dart';
 import 'package:pass_emploi_app/widgets/buttons/primary_action_button.dart';
 import 'package:pass_emploi_app/widgets/buttons/secondary_button.dart';
@@ -87,7 +87,7 @@ class RendezvousDetailsPage extends StatelessWidget {
 
   Widget _content(BuildContext context, RendezvousDetailsViewModel viewModel) {
     if (viewModel.trackingPageName != null) {
-      MatomoTracker.instance.trackScreen(context, eventName: viewModel.trackingPageName!);
+      PassEmploiMatomoTracker.instance.trackScreen(context, eventName: viewModel.trackingPageName!);
     }
     return SingleChildScrollView(
       child: Padding(

--- a/lib/pages/saved_search_tab_page.dart
+++ b/lib/pages/saved_search_tab_page.dart
@@ -1,6 +1,6 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_redux/flutter_redux.dart';
-import 'package:matomo/matomo.dart';
+import 'package:matomo_tracker/matomo_tracker.dart';
 import 'package:pass_emploi_app/analytics/analytics_constants.dart';
 import 'package:pass_emploi_app/features/deep_link/deep_link_state.dart';
 import 'package:pass_emploi_app/features/immersion/list/immersion_list_actions.dart';
@@ -145,20 +145,28 @@ class _SavedSearchTabPageState extends State<SavedSearchTabPage> {
     }
     switch (_selectedIndex) {
       case IndexOf.SERVICE_CIVIQUE:
-        MatomoTracker.trackScreenWithName(
-            AnalyticsScreenNames.savedSearchServiceCiviqueList, AnalyticsScreenNames.savedSearchServiceCiviqueList);
+        MatomoTracker.instance.trackScreenWithName(
+          widgetName: AnalyticsScreenNames.savedSearchServiceCiviqueList,
+          eventName: AnalyticsScreenNames.savedSearchServiceCiviqueList,
+        );
         return _getSavedSearchServiceCivique(viewModel);
       case IndexOf.OFFRES_EMPLOI:
-        MatomoTracker.trackScreenWithName(
-            AnalyticsScreenNames.savedSearchEmploiList, AnalyticsScreenNames.savedSearchEmploiList);
+        MatomoTracker.instance.trackScreenWithName(
+          widgetName: AnalyticsScreenNames.savedSearchEmploiList,
+          eventName: AnalyticsScreenNames.savedSearchEmploiList,
+        );
         return _getSavedSearchOffreEmploi(viewModel, false);
       case IndexOf.ALTERNANCE:
-        MatomoTracker.trackScreenWithName(
-            AnalyticsScreenNames.savedSearchAlternanceList, AnalyticsScreenNames.savedSearchAlternanceList);
+        MatomoTracker.instance.trackScreenWithName(
+          widgetName: AnalyticsScreenNames.savedSearchAlternanceList,
+          eventName: AnalyticsScreenNames.savedSearchAlternanceList,
+        );
         return _getSavedSearchOffreEmploi(viewModel, true);
       default:
-        MatomoTracker.trackScreenWithName(
-            AnalyticsScreenNames.savedSearchEmploiList, AnalyticsScreenNames.savedSearchEmploiList);
+        MatomoTracker.instance.trackScreenWithName(
+          widgetName: AnalyticsScreenNames.savedSearchEmploiList,
+          eventName: AnalyticsScreenNames.savedSearchEmploiList,
+        );
         return _getSavedSearchImmersions(viewModel);
     }
   }

--- a/lib/pages/saved_search_tab_page.dart
+++ b/lib/pages/saved_search_tab_page.dart
@@ -1,6 +1,5 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_redux/flutter_redux.dart';
-import 'package:matomo_tracker/matomo_tracker.dart';
 import 'package:pass_emploi_app/analytics/analytics_constants.dart';
 import 'package:pass_emploi_app/features/deep_link/deep_link_state.dart';
 import 'package:pass_emploi_app/features/immersion/list/immersion_list_actions.dart';
@@ -22,6 +21,7 @@ import 'package:pass_emploi_app/ui/app_colors.dart';
 import 'package:pass_emploi_app/ui/margins.dart';
 import 'package:pass_emploi_app/ui/strings.dart';
 import 'package:pass_emploi_app/ui/text_styles.dart';
+import 'package:pass_emploi_app/utils/pass_emploi_matomo_tracker.dart';
 import 'package:pass_emploi_app/widgets/buttons/carousel_button.dart';
 import 'package:pass_emploi_app/widgets/cards/saved_search_card.dart';
 import 'package:pass_emploi_app/widgets/dialogs/saved_search_delete_dialog.dart';
@@ -145,25 +145,25 @@ class _SavedSearchTabPageState extends State<SavedSearchTabPage> {
     }
     switch (_selectedIndex) {
       case IndexOf.SERVICE_CIVIQUE:
-        MatomoTracker.instance.trackScreenWithName(
+        PassEmploiMatomoTracker.instance.trackScreenWithName(
           widgetName: AnalyticsScreenNames.savedSearchServiceCiviqueList,
           eventName: AnalyticsScreenNames.savedSearchServiceCiviqueList,
         );
         return _getSavedSearchServiceCivique(viewModel);
       case IndexOf.OFFRES_EMPLOI:
-        MatomoTracker.instance.trackScreenWithName(
+        PassEmploiMatomoTracker.instance.trackScreenWithName(
           widgetName: AnalyticsScreenNames.savedSearchEmploiList,
           eventName: AnalyticsScreenNames.savedSearchEmploiList,
         );
         return _getSavedSearchOffreEmploi(viewModel, false);
       case IndexOf.ALTERNANCE:
-        MatomoTracker.instance.trackScreenWithName(
+        PassEmploiMatomoTracker.instance.trackScreenWithName(
           widgetName: AnalyticsScreenNames.savedSearchAlternanceList,
           eventName: AnalyticsScreenNames.savedSearchAlternanceList,
         );
         return _getSavedSearchOffreEmploi(viewModel, true);
       default:
-        MatomoTracker.instance.trackScreenWithName(
+        PassEmploiMatomoTracker.instance.trackScreenWithName(
           widgetName: AnalyticsScreenNames.savedSearchEmploiList,
           eventName: AnalyticsScreenNames.savedSearchEmploiList,
         );

--- a/lib/pages/service_civique/service_civique_list_page.dart
+++ b/lib/pages/service_civique/service_civique_list_page.dart
@@ -1,6 +1,5 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_redux/flutter_redux.dart';
-import 'package:matomo_tracker/matomo_tracker.dart';
 import 'package:pass_emploi_app/analytics/analytics_constants.dart';
 import 'package:pass_emploi_app/analytics/tracker.dart';
 import 'package:pass_emploi_app/features/service_civique/search/search_service_civique_actions.dart';
@@ -18,6 +17,7 @@ import 'package:pass_emploi_app/ui/margins.dart';
 import 'package:pass_emploi_app/ui/strings.dart';
 import 'package:pass_emploi_app/ui/text_styles.dart';
 import 'package:pass_emploi_app/utils/date_extensions.dart';
+import 'package:pass_emploi_app/utils/pass_emploi_matomo_tracker.dart';
 import 'package:pass_emploi_app/utils/string_extensions.dart';
 import 'package:pass_emploi_app/widgets/bottom_sheets/bottom_sheets.dart';
 import 'package:pass_emploi_app/widgets/bottom_sheets/service_civique_saved_search_bottom_sheet.dart';
@@ -224,7 +224,7 @@ class _ServiceCiviqueListPage extends State<ServiceCiviqueListPage> {
   }
 
   Widget _empty(ServiceCiviqueViewModel viewModel) {
-    MatomoTracker.instance.trackScreenWithName(
+    PassEmploiMatomoTracker.instance.trackScreenWithName(
       widgetName: AnalyticsScreenNames.serviceCiviqueNoResults,
       eventName: AnalyticsScreenNames.serviceCiviqueNoResults,
     );

--- a/lib/pages/service_civique/service_civique_list_page.dart
+++ b/lib/pages/service_civique/service_civique_list_page.dart
@@ -1,6 +1,6 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_redux/flutter_redux.dart';
-import 'package:matomo/matomo.dart';
+import 'package:matomo_tracker/matomo_tracker.dart';
 import 'package:pass_emploi_app/analytics/analytics_constants.dart';
 import 'package:pass_emploi_app/analytics/tracker.dart';
 import 'package:pass_emploi_app/features/service_civique/search/search_service_civique_actions.dart';
@@ -224,8 +224,10 @@ class _ServiceCiviqueListPage extends State<ServiceCiviqueListPage> {
   }
 
   Widget _empty(ServiceCiviqueViewModel viewModel) {
-    MatomoTracker.trackScreenWithName(
-        AnalyticsScreenNames.serviceCiviqueNoResults, AnalyticsScreenNames.serviceCiviqueNoResults);
+    MatomoTracker.instance.trackScreenWithName(
+      widgetName: AnalyticsScreenNames.serviceCiviqueNoResults,
+      eventName: AnalyticsScreenNames.serviceCiviqueNoResults,
+    );
     return EmptyOffreWidget(
       withModifyButton: !widget.fromSavedSearch,
       additional: Padding(

--- a/lib/pages/suppression_compte_page.dart
+++ b/lib/pages/suppression_compte_page.dart
@@ -1,6 +1,6 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_redux/flutter_redux.dart';
-import 'package:matomo/matomo.dart';
+import 'package:matomo_tracker/matomo_tracker.dart';
 import 'package:pass_emploi_app/analytics/analytics_constants.dart';
 import 'package:pass_emploi_app/analytics/tracker.dart';
 import 'package:pass_emploi_app/presentation/profil/suppression_compte_view_model.dart';
@@ -115,18 +115,18 @@ class _DeleteAccountButton extends StatelessWidget {
     await showDialog(
       context: context,
       builder: (_) {
-        MatomoTracker.trackScreenWithName(
-          AnalyticsActionNames.suppressionAccountConfirmation,
-          AnalyticsScreenNames.suppressionAccount,
+        MatomoTracker.instance.trackScreenWithName(
+          widgetName: AnalyticsScreenNames.suppressionAccount,
+          eventName: AnalyticsActionNames.suppressionAccountConfirmation,
         );
         return DeleteAlertDialog();
       },
     ).then((result) {
       if (result == true) {
         showSuccessfulSnackBar(context, Strings.accountDeletionSuccess);
-        MatomoTracker.trackScreenWithName(
-          AnalyticsActionNames.suppressionAccountSucceded,
-          AnalyticsScreenNames.suppressionAccount,
+        MatomoTracker.instance.trackScreenWithName(
+          widgetName: AnalyticsScreenNames.suppressionAccount,
+          eventName: AnalyticsActionNames.suppressionAccountSucceded,
         );
       } else if (result == false) {
         showFailedSnackBar(context, Strings.savedSearchDeleteError);

--- a/lib/pages/suppression_compte_page.dart
+++ b/lib/pages/suppression_compte_page.dart
@@ -1,6 +1,5 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_redux/flutter_redux.dart';
-import 'package:matomo_tracker/matomo_tracker.dart';
 import 'package:pass_emploi_app/analytics/analytics_constants.dart';
 import 'package:pass_emploi_app/analytics/tracker.dart';
 import 'package:pass_emploi_app/presentation/profil/suppression_compte_view_model.dart';
@@ -10,6 +9,7 @@ import 'package:pass_emploi_app/ui/font_sizes.dart';
 import 'package:pass_emploi_app/ui/margins.dart';
 import 'package:pass_emploi_app/ui/strings.dart';
 import 'package:pass_emploi_app/ui/text_styles.dart';
+import 'package:pass_emploi_app/utils/pass_emploi_matomo_tracker.dart';
 import 'package:pass_emploi_app/widgets/buttons/primary_action_button.dart';
 import 'package:pass_emploi_app/widgets/default_app_bar.dart';
 import 'package:pass_emploi_app/widgets/dialogs/delete_user_dialog.dart';
@@ -115,7 +115,7 @@ class _DeleteAccountButton extends StatelessWidget {
     await showDialog(
       context: context,
       builder: (_) {
-        MatomoTracker.instance.trackScreenWithName(
+        PassEmploiMatomoTracker.instance.trackScreenWithName(
           widgetName: AnalyticsScreenNames.suppressionAccount,
           eventName: AnalyticsActionNames.suppressionAccountConfirmation,
         );
@@ -124,7 +124,7 @@ class _DeleteAccountButton extends StatelessWidget {
     ).then((result) {
       if (result == true) {
         showSuccessfulSnackBar(context, Strings.accountDeletionSuccess);
-        MatomoTracker.instance.trackScreenWithName(
+        PassEmploiMatomoTracker.instance.trackScreenWithName(
           widgetName: AnalyticsScreenNames.suppressionAccount,
           eventName: AnalyticsActionNames.suppressionAccountSucceded,
         );

--- a/lib/pages/tutorial_page.dart
+++ b/lib/pages/tutorial_page.dart
@@ -1,7 +1,7 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_redux/flutter_redux.dart';
 import 'package:flutter_svg/svg.dart';
-import 'package:matomo/matomo.dart';
+import 'package:matomo_tracker/matomo_tracker.dart';
 import 'package:pass_emploi_app/analytics/analytics_constants.dart';
 import 'package:pass_emploi_app/analytics/tracker.dart';
 import 'package:pass_emploi_app/presentation/tutorial_page_view_model.dart';
@@ -93,15 +93,15 @@ class _TutorialPageState extends State<TutorialPage> {
                           duration: Duration(milliseconds: 600),
                           curve: Curves.linearToEaseOut,
                         );
-                        MatomoTracker.trackScreenWithName(
-                          AnalyticsActionNames.continueTutorial,
-                          AnalyticsScreenNames.tutorialPage,
+                        MatomoTracker.instance.trackScreenWithName(
+                          widgetName: AnalyticsScreenNames.tutorialPage,
+                          eventName: AnalyticsActionNames.continueTutorial,
                         );
                       } else {
                         viewModel.onDone();
-                        MatomoTracker.trackScreenWithName(
-                          AnalyticsActionNames.doneTutorial,
-                          AnalyticsScreenNames.tutorialPage,
+                        MatomoTracker.instance.trackScreenWithName(
+                          widgetName: AnalyticsScreenNames.tutorialPage,
+                          eventName: AnalyticsActionNames.doneTutorial,
                         );
                       }
                     },
@@ -154,10 +154,10 @@ class _SkipButton extends StatelessWidget {
           InkWell(
             onTap: active
                 ? () {
-                    viewModel.onDone();
-                    MatomoTracker.trackScreenWithName(
-                      AnalyticsActionNames.skipTutorial,
-                      AnalyticsScreenNames.tutorialPage,
+              viewModel.onDone();
+                    MatomoTracker.instance.trackScreenWithName(
+                      widgetName: AnalyticsScreenNames.tutorialPage,
+                      eventName: AnalyticsActionNames.skipTutorial,
                     );
                   }
                 : null,
@@ -294,9 +294,9 @@ class _DelayedButton extends StatelessWidget {
           child: InkWell(
             onTap: () {
               viewModel.onDelay();
-              MatomoTracker.trackScreenWithName(
-                AnalyticsActionNames.delayedTutorial,
-                AnalyticsScreenNames.tutorialPage,
+              MatomoTracker.instance.trackScreenWithName(
+                widgetName: AnalyticsScreenNames.tutorialPage,
+                eventName: AnalyticsActionNames.delayedTutorial,
               );
             },
             child: Wrap(

--- a/lib/pages/tutorial_page.dart
+++ b/lib/pages/tutorial_page.dart
@@ -1,7 +1,6 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_redux/flutter_redux.dart';
 import 'package:flutter_svg/svg.dart';
-import 'package:matomo_tracker/matomo_tracker.dart';
 import 'package:pass_emploi_app/analytics/analytics_constants.dart';
 import 'package:pass_emploi_app/analytics/tracker.dart';
 import 'package:pass_emploi_app/presentation/tutorial_page_view_model.dart';
@@ -10,6 +9,7 @@ import 'package:pass_emploi_app/ui/app_colors.dart';
 import 'package:pass_emploi_app/ui/margins.dart';
 import 'package:pass_emploi_app/ui/strings.dart';
 import 'package:pass_emploi_app/ui/text_styles.dart';
+import 'package:pass_emploi_app/utils/pass_emploi_matomo_tracker.dart';
 import 'package:pass_emploi_app/widgets/buttons/primary_action_button.dart';
 import 'package:pass_emploi_app/widgets/primary_rounded_bottom_background.dart';
 import 'package:smooth_page_indicator/smooth_page_indicator.dart';
@@ -93,13 +93,13 @@ class _TutorialPageState extends State<TutorialPage> {
                           duration: Duration(milliseconds: 600),
                           curve: Curves.linearToEaseOut,
                         );
-                        MatomoTracker.instance.trackScreenWithName(
+                        PassEmploiMatomoTracker.instance.trackScreenWithName(
                           widgetName: AnalyticsScreenNames.tutorialPage,
                           eventName: AnalyticsActionNames.continueTutorial,
                         );
                       } else {
                         viewModel.onDone();
-                        MatomoTracker.instance.trackScreenWithName(
+                        PassEmploiMatomoTracker.instance.trackScreenWithName(
                           widgetName: AnalyticsScreenNames.tutorialPage,
                           eventName: AnalyticsActionNames.doneTutorial,
                         );
@@ -155,7 +155,7 @@ class _SkipButton extends StatelessWidget {
             onTap: active
                 ? () {
               viewModel.onDone();
-                    MatomoTracker.instance.trackScreenWithName(
+                    PassEmploiMatomoTracker.instance.trackScreenWithName(
                       widgetName: AnalyticsScreenNames.tutorialPage,
                       eventName: AnalyticsActionNames.skipTutorial,
                     );
@@ -294,7 +294,7 @@ class _DelayedButton extends StatelessWidget {
           child: InkWell(
             onTap: () {
               viewModel.onDelay();
-              MatomoTracker.instance.trackScreenWithName(
+              PassEmploiMatomoTracker.instance.trackScreenWithName(
                 widgetName: AnalyticsScreenNames.tutorialPage,
                 eventName: AnalyticsActionNames.delayedTutorial,
               );

--- a/lib/pages/user_action/action_commentaires_page.dart
+++ b/lib/pages/user_action/action_commentaires_page.dart
@@ -1,7 +1,6 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_redux/flutter_redux.dart';
 import 'package:flutter_svg/flutter_svg.dart';
-import 'package:matomo_tracker/matomo_tracker.dart';
 import 'package:pass_emploi_app/analytics/analytics_constants.dart';
 import 'package:pass_emploi_app/analytics/tracker.dart';
 import 'package:pass_emploi_app/features/user_action/commentaire/create/action_commentaire_create_actions.dart';
@@ -14,6 +13,7 @@ import 'package:pass_emploi_app/ui/drawables.dart';
 import 'package:pass_emploi_app/ui/margins.dart';
 import 'package:pass_emploi_app/ui/strings.dart';
 import 'package:pass_emploi_app/ui/text_styles.dart';
+import 'package:pass_emploi_app/utils/pass_emploi_matomo_tracker.dart';
 import 'package:pass_emploi_app/widgets/comment.dart';
 import 'package:pass_emploi_app/widgets/default_app_bar.dart';
 import 'package:pass_emploi_app/widgets/loading_overlay.dart';
@@ -198,7 +198,7 @@ class _CreateCommentaireWidgetState extends State<_CreateCommentaireWidget> {
               onPressed: () {
                 if (_controller.value.text.isNotEmpty && !_loading()) {
                   widget.viewModel.onSend(_controller.value.text);
-                  MatomoTracker.instance.trackScreenWithName(
+                  PassEmploiMatomoTracker.instance.trackScreenWithName(
                     widgetName: AnalyticsScreenNames.actionCommentsPage,
                     eventName: AnalyticsActionNames.sendComment,
                   );

--- a/lib/pages/user_action/action_commentaires_page.dart
+++ b/lib/pages/user_action/action_commentaires_page.dart
@@ -1,7 +1,7 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_redux/flutter_redux.dart';
 import 'package:flutter_svg/flutter_svg.dart';
-import 'package:matomo/matomo.dart';
+import 'package:matomo_tracker/matomo_tracker.dart';
 import 'package:pass_emploi_app/analytics/analytics_constants.dart';
 import 'package:pass_emploi_app/analytics/tracker.dart';
 import 'package:pass_emploi_app/features/user_action/commentaire/create/action_commentaire_create_actions.dart';
@@ -198,9 +198,9 @@ class _CreateCommentaireWidgetState extends State<_CreateCommentaireWidget> {
               onPressed: () {
                 if (_controller.value.text.isNotEmpty && !_loading()) {
                   widget.viewModel.onSend(_controller.value.text);
-                  MatomoTracker.trackScreenWithName(
-                    AnalyticsActionNames.sendComment,
-                    AnalyticsScreenNames.actionCommentsPage,
+                  MatomoTracker.instance.trackScreenWithName(
+                    widgetName: AnalyticsScreenNames.actionCommentsPage,
+                    eventName: AnalyticsActionNames.sendComment,
                   );
                   _controller.clear();
                 }

--- a/lib/pages/user_action/user_action_detail_page.dart
+++ b/lib/pages/user_action/user_action_detail_page.dart
@@ -1,7 +1,7 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_redux/flutter_redux.dart';
 import 'package:flutter_svg/flutter_svg.dart';
-import 'package:matomo/matomo.dart';
+import 'package:matomo_tracker/matomo_tracker.dart';
 import 'package:pass_emploi_app/analytics/analytics_constants.dart';
 import 'package:pass_emploi_app/analytics/tracker.dart';
 import 'package:pass_emploi_app/features/user_action/commentaire/list/action_commentaire_list_actions.dart';
@@ -151,7 +151,10 @@ class _ActionDetailPageState extends State<UserActionDetailPage> {
   void _onDeleteAction(UserActionDetailsViewModel viewModel) {
     if (viewModel.deleteDisplayState != DeleteDisplayState.SHOW_LOADING) {
       viewModel.onDelete(viewModel.id);
-      MatomoTracker.trackScreenWithName(AnalyticsActionNames.deleteUserAction, AnalyticsScreenNames.userActionDetails);
+      MatomoTracker.instance.trackScreenWithName(
+        widgetName: AnalyticsScreenNames.userActionDetails,
+        eventName: AnalyticsActionNames.deleteUserAction,
+      );
     }
   }
 
@@ -199,7 +202,10 @@ class _ActionDetailPageState extends State<UserActionDetailPage> {
   }
 
   void _trackSuccessfulUpdate() {
-    MatomoTracker.trackScreenWithName(AnalyticsScreenNames.updateUserAction, AnalyticsScreenNames.userActionDetails);
+    MatomoTracker.instance.trackScreenWithName(
+      widgetName: AnalyticsScreenNames.userActionDetails,
+      eventName: AnalyticsScreenNames.updateUserAction,
+    );
   }
 }
 
@@ -377,9 +383,9 @@ class _CommentCard extends StatelessWidget {
   }
 
   void _onCommentClick(BuildContext context, String actionId, String actionTitle) {
-    MatomoTracker.trackScreenWithName(
-      AnalyticsActionNames.accessToActionComments,
-      AnalyticsScreenNames.userActionDetails,
+    MatomoTracker.instance.trackScreenWithName(
+      widgetName: AnalyticsScreenNames.userActionDetails,
+      eventName: AnalyticsActionNames.accessToActionComments,
     );
     Navigator.push(
       context,

--- a/lib/pages/user_action/user_action_detail_page.dart
+++ b/lib/pages/user_action/user_action_detail_page.dart
@@ -1,7 +1,6 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_redux/flutter_redux.dart';
 import 'package:flutter_svg/flutter_svg.dart';
-import 'package:matomo_tracker/matomo_tracker.dart';
 import 'package:pass_emploi_app/analytics/analytics_constants.dart';
 import 'package:pass_emploi_app/analytics/tracker.dart';
 import 'package:pass_emploi_app/features/user_action/commentaire/list/action_commentaire_list_actions.dart';
@@ -20,6 +19,7 @@ import 'package:pass_emploi_app/ui/font_sizes.dart';
 import 'package:pass_emploi_app/ui/margins.dart';
 import 'package:pass_emploi_app/ui/strings.dart';
 import 'package:pass_emploi_app/ui/text_styles.dart';
+import 'package:pass_emploi_app/utils/pass_emploi_matomo_tracker.dart';
 import 'package:pass_emploi_app/widgets/bottom_sheets/bottom_sheets.dart';
 import 'package:pass_emploi_app/widgets/buttons/primary_action_button.dart';
 import 'package:pass_emploi_app/widgets/buttons/secondary_button.dart';
@@ -151,7 +151,7 @@ class _ActionDetailPageState extends State<UserActionDetailPage> {
   void _onDeleteAction(UserActionDetailsViewModel viewModel) {
     if (viewModel.deleteDisplayState != DeleteDisplayState.SHOW_LOADING) {
       viewModel.onDelete(viewModel.id);
-      MatomoTracker.instance.trackScreenWithName(
+      PassEmploiMatomoTracker.instance.trackScreenWithName(
         widgetName: AnalyticsScreenNames.userActionDetails,
         eventName: AnalyticsActionNames.deleteUserAction,
       );
@@ -202,7 +202,7 @@ class _ActionDetailPageState extends State<UserActionDetailPage> {
   }
 
   void _trackSuccessfulUpdate() {
-    MatomoTracker.instance.trackScreenWithName(
+    PassEmploiMatomoTracker.instance.trackScreenWithName(
       widgetName: AnalyticsScreenNames.userActionDetails,
       eventName: AnalyticsScreenNames.updateUserAction,
     );
@@ -383,7 +383,7 @@ class _CommentCard extends StatelessWidget {
   }
 
   void _onCommentClick(BuildContext context, String actionId, String actionTitle) {
-    MatomoTracker.instance.trackScreenWithName(
+    PassEmploiMatomoTracker.instance.trackScreenWithName(
       widgetName: AnalyticsScreenNames.userActionDetails,
       eventName: AnalyticsActionNames.accessToActionComments,
     );

--- a/lib/push/firebase_push_notification_manager.dart
+++ b/lib/push/firebase_push_notification_manager.dart
@@ -74,7 +74,7 @@ class FirebasePushNotificationManager extends PushNotificationManager {
             InitializationSettings(
               android: AndroidInitializationSettings('ic_notification'),
             ),
-            onSelectNotification: (payload) => _onLocalNotificationOpened(payload, store));
+            onDidReceiveNotificationResponse: (response) => _onLocalNotificationOpened(response.payload, store));
         flutterLocalNotificationsPlugin.show(
             notification.hashCode,
             notification.title,

--- a/lib/redux/store_factory.dart
+++ b/lib/redux/store_factory.dart
@@ -1,5 +1,5 @@
 import 'package:flutter/foundation.dart';
-import 'package:matomo/matomo.dart';
+import 'package:matomo_tracker/matomo_tracker.dart';
 import 'package:pass_emploi_app/auth/authenticator.dart';
 import 'package:pass_emploi_app/auth/firebase_auth_wrapper.dart';
 import 'package:pass_emploi_app/configuration/configuration.dart';

--- a/lib/redux/store_factory.dart
+++ b/lib/redux/store_factory.dart
@@ -1,5 +1,4 @@
 import 'package:flutter/foundation.dart';
-import 'package:matomo_tracker/matomo_tracker.dart';
 import 'package:pass_emploi_app/auth/authenticator.dart';
 import 'package:pass_emploi_app/auth/firebase_auth_wrapper.dart';
 import 'package:pass_emploi_app/configuration/configuration.dart';
@@ -106,6 +105,7 @@ import 'package:pass_emploi_app/repositories/suggestions_recherche_repository.da
 import 'package:pass_emploi_app/repositories/suppression_compte_repository.dart';
 import 'package:pass_emploi_app/repositories/tracking_analytics/tracking_event_repository.dart';
 import 'package:pass_emploi_app/repositories/tutorial_repository.dart';
+import 'package:pass_emploi_app/utils/pass_emploi_matomo_tracker.dart';
 /*AUTOGENERATE-REDUX-STOREFACTORY-IMPORT-REPOSITORY*/
 import 'package:redux/redux.dart' as redux;
 
@@ -141,7 +141,7 @@ class StoreFactory {
   final SuppressionCompteRepository suppressionCompteRepository;
   final ModeDemoRepository modeDemoRepository;
   final CampagneRepository campagneRepository;
-  final MatomoTracker matomoTracker;
+  final PassEmploiMatomoTracker matomoTracker;
   final UpdateDemarcheRepository updateDemarcheRepository;
   final CreateDemarcheRepository createDemarcheRepository;
   final SearchDemarcheRepository demarcheDuReferentielRepository;

--- a/lib/utils/pass_emploi_matomo_tracker.dart
+++ b/lib/utils/pass_emploi_matomo_tracker.dart
@@ -1,3 +1,5 @@
+// ignore_for_file: implementation_imports, invalid_use_of_visible_for_testing_member
+
 import 'dart:async';
 import 'dart:collection';
 

--- a/lib/utils/pass_emploi_matomo_tracker.dart
+++ b/lib/utils/pass_emploi_matomo_tracker.dart
@@ -1,0 +1,215 @@
+import 'dart:async';
+import 'dart:collection';
+
+import 'package:flutter/material.dart';
+import 'package:matomo_tracker/matomo_tracker.dart';
+import 'package:matomo_tracker/src/logger.dart';
+import 'package:matomo_tracker/src/matomo_event.dart';
+import 'package:matomo_tracker/src/session.dart';
+import 'package:package_info_plus/package_info_plus.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+class PassEmploiMatomoTracker implements MatomoTracker {
+  final MatomoTracker _decorated = MatomoTracker.instance;
+  Function(String)? onTrackScreen;
+
+  static final instance = PassEmploiMatomoTracker._internal();
+
+  PassEmploiMatomoTracker._internal();
+
+  @override
+  late String contentBase = _decorated.contentBase;
+
+  @override
+  late String? currentScreenId = _decorated.currentScreenId;
+
+  @override
+  late bool initialized = _decorated.initialized;
+
+  @override
+  late Size screenResolution = _decorated.screenResolution;
+
+  @override
+  late Session session = _decorated.session;
+
+  @override
+  late int siteId = _decorated.siteId;
+
+  @override
+  late Timer timer = _decorated.timer;
+
+  @override
+  late String url = _decorated.url;
+
+  @override
+  late String? userAgent = _decorated.userAgent;
+
+  @override
+  void clear() => _decorated.clear();
+
+  @override
+  void dispatchEvents() => _decorated.dispatchEvents();
+
+  @override
+  void dispose() => _decorated.dispose();
+
+  @override
+  String? get getAuthToken => _decorated.getAuthToken;
+
+  @override
+  bool getOptOut() => _decorated.getOptOut();
+
+  @override
+  Visitor get visitor => _decorated.visitor;
+
+  @override
+  Logger get log => _decorated.log;
+
+  @override
+  bool? get optOut => _decorated.optOut;
+
+  @override
+  Queue<MatomoEvent> get queue => _decorated.queue;
+
+  @override
+  Future<void> initialize({
+    required int siteId,
+    required String url,
+    String? visitorId,
+    String? contentBaseUrl,
+    int dequeueInterval = 10,
+    String? tokenAuth,
+    SharedPreferences? prefs,
+    PackageInfo? packageInfo,
+  }) {
+    return _decorated.initialize(
+      siteId: siteId,
+      url: url,
+      visitorId: visitorId,
+      contentBaseUrl: contentBaseUrl,
+      dequeueInterval: dequeueInterval,
+      tokenAuth: tokenAuth,
+      prefs: prefs,
+      packageInfo: packageInfo,
+    );
+  }
+
+  @override
+  void pause() => _decorated.pause();
+
+  @override
+  void resume() => _decorated.resume();
+
+  @override
+  Future<void> setOptOut({required bool optout}) => _decorated.setOptOut(optout: optout);
+
+  @override
+  void setVisitorUserId(String? userId) => _decorated.setVisitorUserId(userId);
+
+  @override
+  void trackCartUpdate(
+    List<TrackingOrderItem>? trackingOrderItems,
+    num? subTotal,
+    num? taxAmount,
+    num? shippingCost,
+    num? discountAmount, {
+    Map<String, String>? dimensions,
+  }) {
+    _decorated.trackCartUpdate(trackingOrderItems, subTotal, taxAmount, shippingCost, discountAmount);
+  }
+
+  @override
+  void trackDimensions(Map<String, String> dimensions) => _decorated.trackDimensions(dimensions);
+
+  @override
+  void trackEvent({
+    required String eventCategory,
+    required String action,
+    String? eventName,
+    int? eventValue,
+    Map<String, String>? dimensions,
+  }) {
+    _decorated.trackEvent(
+      eventCategory: eventCategory,
+      action: action,
+      eventName: eventName,
+      eventValue: eventValue,
+      dimensions: dimensions,
+    );
+  }
+
+  @override
+  void trackGoal(int goalId, {double? revenue, Map<String, String>? dimensions}) {
+    _decorated.trackGoal(goalId, revenue: revenue, dimensions: dimensions);
+  }
+
+  @override
+  void trackOrder(
+    String? orderId,
+    List<TrackingOrderItem>? trackingOrderItems,
+    num? revenue,
+    num? subTotal,
+    num? taxAmount,
+    num? shippingCost,
+    num? discountAmount, {
+    Map<String, String>? dimensions,
+  }) {
+    _decorated.trackOrder(orderId, trackingOrderItems, revenue, subTotal, taxAmount, shippingCost, discountAmount);
+  }
+
+  @override
+  void trackOutlink(String? link, {Map<String, String>? dimensions}) {
+    _decorated.trackOutlink(link, dimensions: dimensions);
+  }
+
+  @override
+  void trackScreen(
+    BuildContext context, {
+    required String eventName,
+    String? currentScreenId,
+    String? path,
+    Map<String, String>? dimensions,
+  }) {
+    _decorated.trackScreen(
+      context,
+      eventName: eventName,
+      currentScreenId: currentScreenId,
+      path: path,
+      dimensions: dimensions,
+    );
+    onTrackScreen?.call(eventName);
+  }
+
+  @override
+  void trackScreenWithName({
+    required String widgetName,
+    required String eventName,
+    String? currentScreenId,
+    String? path,
+    Map<String, String>? dimensions,
+  }) {
+    _decorated.trackScreenWithName(
+      widgetName: widgetName,
+      eventName: eventName,
+      currentScreenId: currentScreenId,
+      path: path,
+      dimensions: dimensions,
+    );
+    onTrackScreen?.call('$eventName in $widgetName');
+  }
+
+  @override
+  void trackSearch({
+    required String searchKeyword,
+    String? searchCategory,
+    int? searchCount,
+    Map<String, String>? dimensions,
+  }) {
+    _decorated.trackSearch(
+      searchKeyword: searchKeyword,
+      searchCategory: searchCategory,
+      searchCount: searchCount,
+      dimensions: dimensions,
+    );
+  }
+}

--- a/lib/widgets/bottom_sheets/immersion_bottom_sheet_form.dart
+++ b/lib/widgets/bottom_sheets/immersion_bottom_sheet_form.dart
@@ -1,6 +1,5 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_svg/svg.dart';
-import 'package:matomo_tracker/matomo_tracker.dart';
 import 'package:pass_emploi_app/analytics/analytics_constants.dart';
 import 'package:pass_emploi_app/models/saved_search/immersion_saved_search.dart';
 import 'package:pass_emploi_app/presentation/saved_search_view_model.dart';
@@ -9,6 +8,7 @@ import 'package:pass_emploi_app/ui/drawables.dart';
 import 'package:pass_emploi_app/ui/margins.dart';
 import 'package:pass_emploi_app/ui/strings.dart';
 import 'package:pass_emploi_app/ui/text_styles.dart';
+import 'package:pass_emploi_app/utils/pass_emploi_matomo_tracker.dart';
 import 'package:pass_emploi_app/widgets/bottom_sheets/bottom_sheets.dart';
 import 'package:pass_emploi_app/widgets/buttons/primary_action_button.dart';
 import 'package:pass_emploi_app/widgets/sepline.dart';
@@ -68,7 +68,7 @@ class _ImmersionBottomSheetFormState extends State<ImmersionBottomSheetForm> {
             onPressed: (_isFormValid())
                 ? () {
               viewModel.createSavedSearch(searchTitle!);
-                    MatomoTracker.instance.trackScreenWithName(
+                    PassEmploiMatomoTracker.instance.trackScreenWithName(
                       widgetName: AnalyticsScreenNames.immersionCreateAlert,
                       eventName: AnalyticsActionNames.createSavedSearchImmersion,
                     );

--- a/lib/widgets/bottom_sheets/immersion_bottom_sheet_form.dart
+++ b/lib/widgets/bottom_sheets/immersion_bottom_sheet_form.dart
@@ -1,6 +1,6 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_svg/svg.dart';
-import 'package:matomo/matomo.dart';
+import 'package:matomo_tracker/matomo_tracker.dart';
 import 'package:pass_emploi_app/analytics/analytics_constants.dart';
 import 'package:pass_emploi_app/models/saved_search/immersion_saved_search.dart';
 import 'package:pass_emploi_app/presentation/saved_search_view_model.dart';
@@ -67,9 +67,11 @@ class _ImmersionBottomSheetFormState extends State<ImmersionBottomSheetForm> {
             iconSize: 18,
             onPressed: (_isFormValid())
                 ? () {
-                    viewModel.createSavedSearch(searchTitle!);
-                    MatomoTracker.trackScreenWithName(
-                        AnalyticsActionNames.createSavedSearchImmersion, AnalyticsScreenNames.immersionCreateAlert);
+              viewModel.createSavedSearch(searchTitle!);
+                    MatomoTracker.instance.trackScreenWithName(
+                      widgetName: AnalyticsScreenNames.immersionCreateAlert,
+                      eventName: AnalyticsActionNames.createSavedSearchImmersion,
+                    );
                   }
                 : null,
           ),

--- a/lib/widgets/bottom_sheets/offre_emploi_bottom_sheet_form.dart
+++ b/lib/widgets/bottom_sheets/offre_emploi_bottom_sheet_form.dart
@@ -1,6 +1,5 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_svg/svg.dart';
-import 'package:matomo_tracker/matomo_tracker.dart';
 import 'package:pass_emploi_app/analytics/analytics_constants.dart';
 import 'package:pass_emploi_app/models/saved_search/offre_emploi_saved_search.dart';
 import 'package:pass_emploi_app/presentation/saved_search_view_model.dart';
@@ -9,6 +8,7 @@ import 'package:pass_emploi_app/ui/drawables.dart';
 import 'package:pass_emploi_app/ui/margins.dart';
 import 'package:pass_emploi_app/ui/strings.dart';
 import 'package:pass_emploi_app/ui/text_styles.dart';
+import 'package:pass_emploi_app/utils/pass_emploi_matomo_tracker.dart';
 import 'package:pass_emploi_app/widgets/bottom_sheets/bottom_sheets.dart';
 import 'package:pass_emploi_app/widgets/bottom_sheets/immersion_bottom_sheet_form.dart';
 import 'package:pass_emploi_app/widgets/buttons/primary_action_button.dart';
@@ -70,7 +70,7 @@ class _OffreEmploiBottomSheetFormState extends State<OffreEmploiBottomSheetForm>
             onPressed: (_isFormValid())
                 ? () {
               viewModel.createSavedSearch(searchTitle!);
-                    MatomoTracker.instance.trackScreenWithName(
+                    PassEmploiMatomoTracker.instance.trackScreenWithName(
                       eventName: widget.onlyAlternance
                           ? AnalyticsScreenNames.alternanceCreateAlert
                           : AnalyticsScreenNames.emploiCreateAlert,

--- a/lib/widgets/bottom_sheets/offre_emploi_bottom_sheet_form.dart
+++ b/lib/widgets/bottom_sheets/offre_emploi_bottom_sheet_form.dart
@@ -1,6 +1,6 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_svg/svg.dart';
-import 'package:matomo/matomo.dart';
+import 'package:matomo_tracker/matomo_tracker.dart';
 import 'package:pass_emploi_app/analytics/analytics_constants.dart';
 import 'package:pass_emploi_app/models/saved_search/offre_emploi_saved_search.dart';
 import 'package:pass_emploi_app/presentation/saved_search_view_model.dart';
@@ -69,12 +69,15 @@ class _OffreEmploiBottomSheetFormState extends State<OffreEmploiBottomSheetForm>
             iconSize: 18,
             onPressed: (_isFormValid())
                 ? () {
-                    viewModel.createSavedSearch(searchTitle!);
-                    widget.onlyAlternance
-                        ? MatomoTracker.trackScreenWithName(AnalyticsActionNames.createSavedSearchAlternance,
-                            AnalyticsScreenNames.alternanceCreateAlert)
-                        : MatomoTracker.trackScreenWithName(
-                            AnalyticsActionNames.createSavedSearchEmploi, AnalyticsScreenNames.emploiCreateAlert);
+              viewModel.createSavedSearch(searchTitle!);
+                    MatomoTracker.instance.trackScreenWithName(
+                      eventName: widget.onlyAlternance
+                          ? AnalyticsScreenNames.alternanceCreateAlert
+                          : AnalyticsScreenNames.emploiCreateAlert,
+                      widgetName: widget.onlyAlternance
+                          ? AnalyticsActionNames.createSavedSearchAlternance
+                          : AnalyticsActionNames.createSavedSearchEmploi,
+                    );
                   }
                 : null,
           ),

--- a/lib/widgets/bottom_sheets/rating_bottom_sheet.dart
+++ b/lib/widgets/bottom_sheets/rating_bottom_sheet.dart
@@ -2,7 +2,7 @@ import 'package:flutter/material.dart';
 import 'package:flutter_redux/flutter_redux.dart';
 import 'package:flutter_svg/flutter_svg.dart';
 import 'package:in_app_review/in_app_review.dart';
-import 'package:matomo/matomo.dart';
+import 'package:matomo_tracker/matomo_tracker.dart';
 import 'package:pass_emploi_app/analytics/analytics_constants.dart';
 import 'package:pass_emploi_app/presentation/rating_view_model.dart';
 import 'package:pass_emploi_app/redux/app_state.dart';
@@ -117,4 +117,6 @@ class _RatingHeader extends StatelessWidget {
   }
 }
 
-void _matomoTracking(String action) => MatomoTracker.trackScreenWithName(action, AnalyticsScreenNames.ratingPage);
+void _matomoTracking(String action) {
+  MatomoTracker.instance.trackScreenWithName(widgetName: AnalyticsScreenNames.ratingPage, eventName: action);
+}

--- a/lib/widgets/bottom_sheets/rating_bottom_sheet.dart
+++ b/lib/widgets/bottom_sheets/rating_bottom_sheet.dart
@@ -2,7 +2,6 @@ import 'package:flutter/material.dart';
 import 'package:flutter_redux/flutter_redux.dart';
 import 'package:flutter_svg/flutter_svg.dart';
 import 'package:in_app_review/in_app_review.dart';
-import 'package:matomo_tracker/matomo_tracker.dart';
 import 'package:pass_emploi_app/analytics/analytics_constants.dart';
 import 'package:pass_emploi_app/presentation/rating_view_model.dart';
 import 'package:pass_emploi_app/redux/app_state.dart';
@@ -11,6 +10,7 @@ import 'package:pass_emploi_app/ui/drawables.dart';
 import 'package:pass_emploi_app/ui/strings.dart';
 import 'package:pass_emploi_app/ui/text_styles.dart';
 import 'package:pass_emploi_app/utils/mail_handler.dart';
+import 'package:pass_emploi_app/utils/pass_emploi_matomo_tracker.dart';
 import 'package:pass_emploi_app/widgets/cards/rating_card.dart';
 import 'package:pass_emploi_app/widgets/sepline.dart';
 import 'package:pass_emploi_app/widgets/snack_bar/show_snack_bar.dart';
@@ -118,5 +118,5 @@ class _RatingHeader extends StatelessWidget {
 }
 
 void _matomoTracking(String action) {
-  MatomoTracker.instance.trackScreenWithName(widgetName: AnalyticsScreenNames.ratingPage, eventName: action);
+  PassEmploiMatomoTracker.instance.trackScreenWithName(widgetName: AnalyticsScreenNames.ratingPage, eventName: action);
 }

--- a/lib/widgets/bottom_sheets/service_civique_bottom_sheet_form.dart
+++ b/lib/widgets/bottom_sheets/service_civique_bottom_sheet_form.dart
@@ -1,6 +1,5 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_svg/svg.dart';
-import 'package:matomo_tracker/matomo_tracker.dart';
 import 'package:pass_emploi_app/analytics/analytics_constants.dart';
 import 'package:pass_emploi_app/models/saved_search/service_civique_saved_search.dart';
 import 'package:pass_emploi_app/presentation/saved_search_view_model.dart';
@@ -9,6 +8,7 @@ import 'package:pass_emploi_app/ui/drawables.dart';
 import 'package:pass_emploi_app/ui/margins.dart';
 import 'package:pass_emploi_app/ui/strings.dart';
 import 'package:pass_emploi_app/ui/text_styles.dart';
+import 'package:pass_emploi_app/utils/pass_emploi_matomo_tracker.dart';
 import 'package:pass_emploi_app/widgets/bottom_sheets/bottom_sheets.dart';
 import 'package:pass_emploi_app/widgets/buttons/primary_action_button.dart';
 import 'package:pass_emploi_app/widgets/sepline.dart';
@@ -68,7 +68,7 @@ class _ServiceCiviqueBottomSheetFormState extends State<ServiceCiviqueBottomShee
             onPressed: (_isFormValid())
                 ? () {
               viewModel.createSavedSearch(searchTitle!);
-                    MatomoTracker.instance.trackScreenWithName(
+                    PassEmploiMatomoTracker.instance.trackScreenWithName(
                       widgetName: AnalyticsScreenNames.serviceCiviqueCreateAlert,
                       eventName: AnalyticsActionNames.createSavedSearchServiceCivique,
                     );

--- a/lib/widgets/bottom_sheets/service_civique_bottom_sheet_form.dart
+++ b/lib/widgets/bottom_sheets/service_civique_bottom_sheet_form.dart
@@ -1,6 +1,6 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_svg/svg.dart';
-import 'package:matomo/matomo.dart';
+import 'package:matomo_tracker/matomo_tracker.dart';
 import 'package:pass_emploi_app/analytics/analytics_constants.dart';
 import 'package:pass_emploi_app/models/saved_search/service_civique_saved_search.dart';
 import 'package:pass_emploi_app/presentation/saved_search_view_model.dart';
@@ -67,9 +67,11 @@ class _ServiceCiviqueBottomSheetFormState extends State<ServiceCiviqueBottomShee
             iconSize: 18,
             onPressed: (_isFormValid())
                 ? () {
-                    viewModel.createSavedSearch(searchTitle!);
-                    MatomoTracker.trackScreenWithName(AnalyticsActionNames.createSavedSearchServiceCivique,
-                        AnalyticsScreenNames.serviceCiviqueCreateAlert);
+              viewModel.createSavedSearch(searchTitle!);
+                    MatomoTracker.instance.trackScreenWithName(
+                      widgetName: AnalyticsScreenNames.serviceCiviqueCreateAlert,
+                      eventName: AnalyticsActionNames.createSavedSearchServiceCivique,
+                    );
                   }
                 : null,
           ),

--- a/lib/widgets/buttons/delete_favori_button.dart
+++ b/lib/widgets/buttons/delete_favori_button.dart
@@ -1,6 +1,6 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_redux/flutter_redux.dart';
-import 'package:matomo/matomo.dart';
+import 'package:matomo_tracker/matomo_tracker.dart';
 import 'package:pass_emploi_app/pages/offre_page.dart';
 import 'package:pass_emploi_app/presentation/favori_heart_view_model.dart';
 import 'package:pass_emploi_app/redux/app_state.dart';
@@ -46,6 +46,8 @@ class DeleteFavoriButton<T> extends StatelessWidget {
   void _tracking() {
     final widgetName = FavoriHeartAnalyticsHelper().getAnalyticsWidgetName(from, false);
     final eventName = FavoriHeartAnalyticsHelper().getAnalyticsEventName(from);
-    if (widgetName != null && eventName != null) MatomoTracker.trackScreenWithName(widgetName, eventName);
+    if (widgetName != null && eventName != null) {
+      MatomoTracker.instance.trackScreenWithName(widgetName: widgetName, eventName: eventName);
+    }
   }
 }

--- a/lib/widgets/buttons/delete_favori_button.dart
+++ b/lib/widgets/buttons/delete_favori_button.dart
@@ -1,10 +1,10 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_redux/flutter_redux.dart';
-import 'package:matomo_tracker/matomo_tracker.dart';
 import 'package:pass_emploi_app/pages/offre_page.dart';
 import 'package:pass_emploi_app/presentation/favori_heart_view_model.dart';
 import 'package:pass_emploi_app/redux/app_state.dart';
 import 'package:pass_emploi_app/ui/strings.dart';
+import 'package:pass_emploi_app/utils/pass_emploi_matomo_tracker.dart';
 import 'package:pass_emploi_app/widgets/buttons/primary_action_button.dart';
 import 'package:pass_emploi_app/widgets/favori_heart.dart';
 import 'package:pass_emploi_app/widgets/favori_state_selector.dart';
@@ -47,7 +47,7 @@ class DeleteFavoriButton<T> extends StatelessWidget {
     final widgetName = FavoriHeartAnalyticsHelper().getAnalyticsWidgetName(from, false);
     final eventName = FavoriHeartAnalyticsHelper().getAnalyticsEventName(from);
     if (widgetName != null && eventName != null) {
-      MatomoTracker.instance.trackScreenWithName(widgetName: widgetName, eventName: eventName);
+      PassEmploiMatomoTracker.instance.trackScreenWithName(widgetName: widgetName, eventName: eventName);
     }
   }
 }

--- a/lib/widgets/cards/boite_a_outils_card.dart
+++ b/lib/widgets/cards/boite_a_outils_card.dart
@@ -1,10 +1,10 @@
 import 'package:flutter/material.dart';
-import 'package:matomo_tracker/matomo_tracker.dart';
 import 'package:pass_emploi_app/models/outil.dart';
 import 'package:pass_emploi_app/ui/app_colors.dart';
 import 'package:pass_emploi_app/ui/margins.dart';
 import 'package:pass_emploi_app/ui/text_styles.dart';
 import 'package:pass_emploi_app/utils/launcher_utils.dart';
+import 'package:pass_emploi_app/utils/pass_emploi_matomo_tracker.dart';
 import 'package:pass_emploi_app/widgets/sepline.dart';
 
 class BoiteAOutilsCard extends StatelessWidget {
@@ -25,7 +25,7 @@ class BoiteAOutilsCard extends StatelessWidget {
       child: InkWell(
         customBorder: roundedCornerShape,
         onTap: () {
-          MatomoTracker.instance.trackOutlink(outil.urlRedirect);
+          PassEmploiMatomoTracker.instance.trackOutlink(outil.urlRedirect);
           launchExternalUrl(outil.urlRedirect);
         },
         child: Column(

--- a/lib/widgets/cards/boite_a_outils_card.dart
+++ b/lib/widgets/cards/boite_a_outils_card.dart
@@ -1,5 +1,5 @@
 import 'package:flutter/material.dart';
-import 'package:matomo/matomo.dart';
+import 'package:matomo_tracker/matomo_tracker.dart';
 import 'package:pass_emploi_app/models/outil.dart';
 import 'package:pass_emploi_app/ui/app_colors.dart';
 import 'package:pass_emploi_app/ui/margins.dart';
@@ -25,7 +25,7 @@ class BoiteAOutilsCard extends StatelessWidget {
       child: InkWell(
         customBorder: roundedCornerShape,
         onTap: () {
-          MatomoTracker.trackOutlink(outil.urlRedirect);
+          MatomoTracker.instance.trackOutlink(outil.urlRedirect);
           launchExternalUrl(outil.urlRedirect);
         },
         child: Column(

--- a/lib/widgets/dialogs/saved_search_delete_dialog.dart
+++ b/lib/widgets/dialogs/saved_search_delete_dialog.dart
@@ -1,7 +1,7 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_redux/flutter_redux.dart';
 import 'package:flutter_svg/svg.dart';
-import 'package:matomo/matomo.dart';
+import 'package:matomo_tracker/matomo_tracker.dart';
 import 'package:pass_emploi_app/analytics/analytics_constants.dart';
 import 'package:pass_emploi_app/analytics/tracker.dart';
 import 'package:pass_emploi_app/features/saved_search/delete/saved_search_delete_actions.dart';
@@ -59,7 +59,7 @@ class SavedSearchDeleteDialog extends StatelessWidget {
         builder: (context, viewModel) => _alertDialog(context, viewModel),
         onWillChange: (_, viewModel) {
           if (viewModel.displayState == SavedSearchDeleteDisplayState.SUCCESS) {
-            MatomoTracker.trackScreenWithName(_actionName(type), _screenName(type));
+            MatomoTracker.instance.trackScreenWithName(widgetName: _screenName(type), eventName: _actionName(type));
             Navigator.pop(context, true);
           }
         },

--- a/lib/widgets/dialogs/saved_search_delete_dialog.dart
+++ b/lib/widgets/dialogs/saved_search_delete_dialog.dart
@@ -1,7 +1,6 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_redux/flutter_redux.dart';
 import 'package:flutter_svg/svg.dart';
-import 'package:matomo_tracker/matomo_tracker.dart';
 import 'package:pass_emploi_app/analytics/analytics_constants.dart';
 import 'package:pass_emploi_app/analytics/tracker.dart';
 import 'package:pass_emploi_app/features/saved_search/delete/saved_search_delete_actions.dart';
@@ -13,6 +12,7 @@ import 'package:pass_emploi_app/ui/font_sizes.dart';
 import 'package:pass_emploi_app/ui/margins.dart';
 import 'package:pass_emploi_app/ui/strings.dart';
 import 'package:pass_emploi_app/ui/text_styles.dart';
+import 'package:pass_emploi_app/utils/pass_emploi_matomo_tracker.dart';
 import 'package:pass_emploi_app/widgets/buttons/primary_action_button.dart';
 import 'package:pass_emploi_app/widgets/buttons/secondary_button.dart';
 
@@ -59,7 +59,7 @@ class SavedSearchDeleteDialog extends StatelessWidget {
         builder: (context, viewModel) => _alertDialog(context, viewModel),
         onWillChange: (_, viewModel) {
           if (viewModel.displayState == SavedSearchDeleteDisplayState.SUCCESS) {
-            MatomoTracker.instance.trackScreenWithName(widgetName: _screenName(type), eventName: _actionName(type));
+            PassEmploiMatomoTracker.instance.trackScreenWithName(widgetName: _screenName(type), eventName: _actionName(type));
             Navigator.pop(context, true);
           }
         },

--- a/lib/widgets/favori_heart.dart
+++ b/lib/widgets/favori_heart.dart
@@ -1,6 +1,5 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_redux/flutter_redux.dart';
-import 'package:matomo_tracker/matomo_tracker.dart';
 import 'package:pass_emploi_app/analytics/analytics_constants.dart';
 import 'package:pass_emploi_app/pages/offre_page.dart';
 import 'package:pass_emploi_app/presentation/favori_heart_view_model.dart';
@@ -8,6 +7,7 @@ import 'package:pass_emploi_app/redux/app_state.dart';
 import 'package:pass_emploi_app/ui/app_colors.dart';
 import 'package:pass_emploi_app/ui/drawables.dart';
 import 'package:pass_emploi_app/ui/strings.dart';
+import 'package:pass_emploi_app/utils/pass_emploi_matomo_tracker.dart';
 import 'package:pass_emploi_app/widgets/buttons/debounced_button.dart';
 import 'package:pass_emploi_app/widgets/buttons/secondary_icon_button.dart';
 import 'package:pass_emploi_app/widgets/favori_state_selector.dart';
@@ -69,7 +69,7 @@ class FavoriHeart<T> extends StatelessWidget {
     final widgetName = FavoriHeartAnalyticsHelper().getAnalyticsWidgetName(from, newFavoriStatus);
     final eventName = FavoriHeartAnalyticsHelper().getAnalyticsEventName(from);
     if (widgetName != null && eventName != null) {
-      MatomoTracker.instance.trackScreenWithName(widgetName: widgetName, eventName: eventName);
+      PassEmploiMatomoTracker.instance.trackScreenWithName(widgetName: widgetName, eventName: eventName);
     }
   }
 }

--- a/lib/widgets/favori_heart.dart
+++ b/lib/widgets/favori_heart.dart
@@ -1,6 +1,6 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_redux/flutter_redux.dart';
-import 'package:matomo/matomo.dart';
+import 'package:matomo_tracker/matomo_tracker.dart';
 import 'package:pass_emploi_app/analytics/analytics_constants.dart';
 import 'package:pass_emploi_app/pages/offre_page.dart';
 import 'package:pass_emploi_app/presentation/favori_heart_view_model.dart';
@@ -68,7 +68,9 @@ class FavoriHeart<T> extends StatelessWidget {
     final newFavoriStatus = !isFavori;
     final widgetName = FavoriHeartAnalyticsHelper().getAnalyticsWidgetName(from, newFavoriStatus);
     final eventName = FavoriHeartAnalyticsHelper().getAnalyticsEventName(from);
-    if (widgetName != null && eventName != null) MatomoTracker.trackScreenWithName(widgetName, eventName);
+    if (widgetName != null && eventName != null) {
+      MatomoTracker.instance.trackScreenWithName(widgetName: widgetName, eventName: eventName);
+    }
   }
 }
 

--- a/lib/widgets/preview_file_invisible_handler.dart
+++ b/lib/widgets/preview_file_invisible_handler.dart
@@ -1,6 +1,6 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_redux/flutter_redux.dart';
-import 'package:open_file/open_file.dart';
+import 'package:open_filex/open_filex.dart';
 import 'package:pass_emploi_app/presentation/preview_file_view_model.dart';
 import 'package:pass_emploi_app/redux/app_state.dart';
 
@@ -23,7 +23,7 @@ class PreviewFileInvisibleHandler extends StatelessWidget {
     final path = viewModel.path;
     if (path == null) return;
 
-    OpenFile.open(path);
+    OpenFilex.open(path);
 
     viewModel.viewClosed();
   }

--- a/lib/widgets/snack_bar/rating_snack_bar.dart
+++ b/lib/widgets/snack_bar/rating_snack_bar.dart
@@ -1,7 +1,7 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_redux/flutter_redux.dart';
 import 'package:flutter_svg/svg.dart';
-import 'package:matomo/matomo.dart';
+import 'package:matomo_tracker/matomo_tracker.dart';
 import 'package:pass_emploi_app/analytics/analytics_constants.dart';
 import 'package:pass_emploi_app/presentation/rating_view_model.dart';
 import 'package:pass_emploi_app/redux/app_state.dart';
@@ -38,7 +38,7 @@ class _DismissSnackBar extends StatelessWidget {
     return StoreConnector<AppState, RatingViewModel>(
       converter: (store) => RatingViewModel.create(store),
       builder: (context, viewModel) => _body(context, viewModel),
-     );
+    );
   }
 
   Widget _body(BuildContext context, RatingViewModel viewModel) {
@@ -54,7 +54,10 @@ class _DismissSnackBar extends StatelessWidget {
   void _onDismiss(BuildContext context, RatingViewModel viewModel) {
     viewModel.onDone();
     snackbarKey.currentState?.hideCurrentSnackBar();
-    MatomoTracker.trackScreenWithName(AnalyticsActionNames.skipRating, AnalyticsScreenNames.ratingPage);
+    MatomoTracker.instance.trackScreenWithName(
+      widgetName: AnalyticsScreenNames.ratingPage,
+      eventName: AnalyticsActionNames.skipRating,
+    );
   }
 }
 

--- a/lib/widgets/snack_bar/rating_snack_bar.dart
+++ b/lib/widgets/snack_bar/rating_snack_bar.dart
@@ -1,7 +1,6 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_redux/flutter_redux.dart';
 import 'package:flutter_svg/svg.dart';
-import 'package:matomo_tracker/matomo_tracker.dart';
 import 'package:pass_emploi_app/analytics/analytics_constants.dart';
 import 'package:pass_emploi_app/presentation/rating_view_model.dart';
 import 'package:pass_emploi_app/redux/app_state.dart';
@@ -9,6 +8,7 @@ import 'package:pass_emploi_app/ui/app_colors.dart';
 import 'package:pass_emploi_app/ui/drawables.dart';
 import 'package:pass_emploi_app/ui/strings.dart';
 import 'package:pass_emploi_app/ui/text_styles.dart';
+import 'package:pass_emploi_app/utils/pass_emploi_matomo_tracker.dart';
 import 'package:pass_emploi_app/widgets/bottom_sheets/bottom_sheets.dart';
 import 'package:pass_emploi_app/widgets/bottom_sheets/rating_bottom_sheet.dart';
 import 'package:pass_emploi_app/widgets/snack_bar/show_snack_bar.dart';
@@ -54,7 +54,7 @@ class _DismissSnackBar extends StatelessWidget {
   void _onDismiss(BuildContext context, RatingViewModel viewModel) {
     viewModel.onDone();
     snackbarKey.currentState?.hideCurrentSnackBar();
-    MatomoTracker.instance.trackScreenWithName(
+    PassEmploiMatomoTracker.instance.trackScreenWithName(
       widgetName: AnalyticsScreenNames.ratingPage,
       eventName: AnalyticsActionNames.skipRating,
     );

--- a/lib/widgets/text_with_clickable_links.dart
+++ b/lib/widgets/text_with_clickable_links.dart
@@ -1,6 +1,6 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_linkify/flutter_linkify.dart';
-import 'package:matomo/matomo.dart';
+import 'package:matomo_tracker/matomo_tracker.dart';
 import 'package:pass_emploi_app/ui/text_styles.dart';
 import 'package:pass_emploi_app/utils/launcher_utils.dart';
 
@@ -19,7 +19,7 @@ class TextWithClickableLinks extends StatelessWidget {
       linkStyle: linkStyle ?? TextStyles.externalLink,
       onOpen: (link) {
         final String baseUrl = Uri.parse(link.url).origin;
-        MatomoTracker.trackOutlink(baseUrl);
+        MatomoTracker.instance.trackOutlink(baseUrl);
         launchExternalUrl(link.url);
       },
       options: LinkifyOptions(
@@ -46,7 +46,7 @@ class SelectableTextWithClickableLinks extends StatelessWidget {
       linkStyle: linkStyle ?? TextStyles.externalLink,
       onOpen: (link) {
         final String baseUrl = Uri.parse(link.url).origin;
-        MatomoTracker.trackOutlink(baseUrl);
+        MatomoTracker.instance.trackOutlink(baseUrl);
         launchExternalUrl(link.url);
       },
       options: LinkifyOptions(

--- a/lib/widgets/text_with_clickable_links.dart
+++ b/lib/widgets/text_with_clickable_links.dart
@@ -1,8 +1,8 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_linkify/flutter_linkify.dart';
-import 'package:matomo_tracker/matomo_tracker.dart';
 import 'package:pass_emploi_app/ui/text_styles.dart';
 import 'package:pass_emploi_app/utils/launcher_utils.dart';
+import 'package:pass_emploi_app/utils/pass_emploi_matomo_tracker.dart';
 
 class TextWithClickableLinks extends StatelessWidget {
   final String content;
@@ -19,7 +19,7 @@ class TextWithClickableLinks extends StatelessWidget {
       linkStyle: linkStyle ?? TextStyles.externalLink,
       onOpen: (link) {
         final String baseUrl = Uri.parse(link.url).origin;
-        MatomoTracker.instance.trackOutlink(baseUrl);
+        PassEmploiMatomoTracker.instance.trackOutlink(baseUrl);
         launchExternalUrl(link.url);
       },
       options: LinkifyOptions(
@@ -46,7 +46,7 @@ class SelectableTextWithClickableLinks extends StatelessWidget {
       linkStyle: linkStyle ?? TextStyles.externalLink,
       onOpen: (link) {
         final String baseUrl = Uri.parse(link.url).origin;
-        MatomoTracker.instance.trackOutlink(baseUrl);
+        PassEmploiMatomoTracker.instance.trackOutlink(baseUrl);
         launchExternalUrl(link.url);
       },
       options: LinkifyOptions(

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -147,7 +147,7 @@ packages:
       name: dbus
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.7.3"
+    version: "0.7.8"
   device_info_plus:
     dependency: transitive
     description:
@@ -184,7 +184,7 @@ packages:
     source: hosted
     version: "1.3.1"
   ffi:
-    dependency: "direct overridden"
+    dependency: transitive
     description:
       name: ffi
       url: "https://pub.dartlang.org"
@@ -362,21 +362,21 @@ packages:
       name: flutter_local_notifications
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "9.5.0"
+    version: "12.0.4"
   flutter_local_notifications_linux:
     dependency: transitive
     description:
       name: flutter_local_notifications_linux
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.4.2"
+    version: "2.0.0"
   flutter_local_notifications_platform_interface:
     dependency: transitive
     description:
       name: flutter_local_notifications_platform_interface
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "5.0.0"
+    version: "6.0.0"
   flutter_localizations:
     dependency: "direct main"
     description: flutter
@@ -437,7 +437,7 @@ packages:
       name: flutter_svg
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.0.3"
+    version: "1.1.6"
   flutter_test:
     dependency: "direct dev"
     description: flutter
@@ -581,13 +581,13 @@ packages:
       url: "https://pub.dartlang.org"
     source: hosted
     version: "1.0.2"
-  open_file:
+  open_filex:
     dependency: "direct main"
     description:
-      name: open_file
+      name: open_filex
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "3.2.1"
+    version: "4.3.1"
   package_config:
     dependency: transitive
     description:
@@ -629,14 +629,14 @@ packages:
       name: path_drawing
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.0.0"
+    version: "1.0.1"
   path_parsing:
     dependency: transitive
     description:
       name: path_parsing
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.0.0"
+    version: "1.0.1"
   path_provider:
     dependency: "direct main"
     description:
@@ -664,7 +664,7 @@ packages:
       name: path_provider_linux
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.1.5"
+    version: "2.1.7"
   path_provider_macos:
     dependency: transitive
     description:
@@ -685,7 +685,7 @@ packages:
       name: path_provider_windows
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.0.5"
+    version: "2.1.3"
   pedantic:
     dependency: transitive
     description:
@@ -699,7 +699,7 @@ packages:
       name: petitparser
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "4.4.0"
+    version: "5.1.0"
   platform:
     dependency: transitive
     description:
@@ -928,7 +928,7 @@ packages:
       name: timezone
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.8.0"
+    version: "0.9.0"
   typed_data:
     dependency: transitive
     description:
@@ -1033,7 +1033,7 @@ packages:
       name: xml
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "5.3.1"
+    version: "6.1.0"
   yaml:
     dependency: transitive
     description:

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -148,6 +148,20 @@ packages:
       url: "https://pub.dartlang.org"
     source: hosted
     version: "0.7.3"
+  device_info_plus:
+    dependency: transitive
+    description:
+      name: device_info_plus
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "8.0.0"
+  device_info_plus_platform_interface:
+    dependency: transitive
+    description:
+      name: device_info_plus_platform_interface
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "7.0.0"
   encrypt:
     dependency: "direct main"
     description:
@@ -170,12 +184,12 @@ packages:
     source: hosted
     version: "1.3.1"
   ffi:
-    dependency: transitive
+    dependency: "direct overridden"
     description:
       name: ffi
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.1.2"
+    version: "2.0.1"
   file:
     dependency: transitive
     description:
@@ -295,13 +309,6 @@ packages:
       url: "https://pub.dartlang.org"
     source: hosted
     version: "1.0.11"
-  fk_user_agent:
-    dependency: transitive
-    description:
-      name: fk_user_agent
-      url: "https://pub.dartlang.org"
-    source: hosted
-    version: "2.1.0"
   flutter:
     dependency: "direct main"
     description: flutter
@@ -475,7 +482,7 @@ packages:
       name: http
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.13.4"
+    version: "0.13.5"
   http_interceptor:
     dependency: "direct main"
     description:
@@ -539,13 +546,6 @@ packages:
       url: "https://pub.dartlang.org"
     source: hosted
     version: "1.1.0"
-  logging:
-    dependency: transitive
-    description:
-      name: logging
-      url: "https://pub.dartlang.org"
-    source: hosted
-    version: "1.0.2"
   matcher:
     dependency: transitive
     description:
@@ -560,15 +560,13 @@ packages:
       url: "https://pub.dartlang.org"
     source: hosted
     version: "0.1.5"
-  matomo:
+  matomo_tracker:
     dependency: "direct main"
     description:
-      path: "."
-      ref: "feat/add-outlink-support"
-      resolved-ref: "745ccc814561e4aeaeec9f867e24d32e21e623c6"
-      url: "https://github.com/BonnetM/dart-matomo.git"
-    source: git
-    version: "1.1.0"
+      name: matomo_tracker
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "2.0.0"
   meta:
     dependency: transitive
     description:
@@ -610,42 +608,14 @@ packages:
       name: package_info_plus
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.4.2"
-  package_info_plus_linux:
-    dependency: transitive
-    description:
-      name: package_info_plus_linux
-      url: "https://pub.dartlang.org"
-    source: hosted
-    version: "1.0.5"
-  package_info_plus_macos:
-    dependency: transitive
-    description:
-      name: package_info_plus_macos
-      url: "https://pub.dartlang.org"
-    source: hosted
-    version: "1.3.0"
+    version: "3.0.2"
   package_info_plus_platform_interface:
     dependency: transitive
     description:
       name: package_info_plus_platform_interface
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.0.2"
-  package_info_plus_web:
-    dependency: transitive
-    description:
-      name: package_info_plus_web
-      url: "https://pub.dartlang.org"
-    source: hosted
-    version: "1.0.5"
-  package_info_plus_windows:
-    dependency: transitive
-    description:
-      name: package_info_plus_windows
-      url: "https://pub.dartlang.org"
-    source: hosted
-    version: "1.0.5"
+    version: "2.0.1"
   path:
     dependency: transitive
     description:
@@ -827,7 +797,7 @@ packages:
       name: shared_preferences
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.0.13"
+    version: "2.0.15"
   shared_preferences_android:
     dependency: transitive
     description:
@@ -966,20 +936,6 @@ packages:
       url: "https://pub.dartlang.org"
     source: hosted
     version: "1.3.0"
-  universal_html:
-    dependency: transitive
-    description:
-      name: universal_html
-      url: "https://pub.dartlang.org"
-    source: hosted
-    version: "2.0.8"
-  universal_io:
-    dependency: transitive
-    description:
-      name: universal_io
-      url: "https://pub.dartlang.org"
-    source: hosted
-    version: "2.0.4"
   url_launcher:
     dependency: "direct main"
     description:
@@ -1042,7 +998,7 @@ packages:
       name: uuid
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "3.0.6"
+    version: "3.0.7"
   vector_math:
     dependency: transitive
     description:
@@ -1063,7 +1019,7 @@ packages:
       name: win32
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.5.2"
+    version: "2.7.0"
   xdg_directories:
     dependency: transitive
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -14,18 +14,22 @@ dependencies:
     sdk: flutter
   flutter_localizations:
     sdk: flutter
-  flutter_svg: '1.0.3'
+  flutter_svg: '1.1.6'
   flutter_redux: '0.10.0'
-  package_info: '2.0.2'
-  flutter_local_notifications: '9.5.0'
+  flutter_local_notifications: '12.0.4'
   flutter_dotenv: '5.0.2'
-  url_launcher: '6.1.0'
   flutter_appauth: '2.4.1+1'
   flutter_linkify: '5.0.2'
-  share_plus: '4.0.4'
   flutter_secure_storage: '5.0.2'
-  open_file: '3.2.1'
+  flutter_cache_manager: '3.3.0'
+  package_info: '2.0.2'
+  url_launcher: '6.1.0'
+  share_plus: '4.0.4'
+  open_filex: '4.3.1'
   path_provider: '2.0.11'
+  google_fonts: '2.3.2'
+  smooth_page_indicator: '1.0.0+2'
+  in_app_review: '2.0.4'
   # Dart
   http: '0.13.5'
   http_interceptor: '1.0.2'
@@ -34,6 +38,9 @@ dependencies:
   equatable: '2.0.3'
   logger: '1.1.0'
   uuid: '3.0.7'
+  synchronized: '3.0.0+2'
+  encrypt: '5.0.1'
+  matomo_tracker: '2.0.0'
   # Firebase
   firebase_core: '1.16.0'
   firebase_crashlytics: '2.7.2'
@@ -41,27 +48,13 @@ dependencies:
   firebase_messaging: '11.3.0'
   firebase_auth: '3.3.17'
   cloud_firestore: '3.1.14'
-  synchronized: '3.0.0+2'
-  flutter_cache_manager: '3.3.0'
   flutterfire_installations: '0.1.0'
-  # UI
-  google_fonts: '2.3.2'
-  # Analytics
-  matomo_tracker: '2.0.0'
-
-  encrypt: '5.0.1'
-  smooth_page_indicator: '1.0.0+2'
-  in_app_review: '2.0.4'
-
-dependency_overrides:
-  ffi: '2.0.1'
 
 dev_dependencies:
   flutter_test:
     sdk: flutter
   flutter_lints: ^1.0.4
   dart_code_metrics: ^4.14.0
-
 
 flutter:
 

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -27,13 +27,13 @@ dependencies:
   open_file: '3.2.1'
   path_provider: '2.0.11'
   # Dart
-  http: '0.13.4'
+  http: '0.13.5'
   http_interceptor: '1.0.2'
   intl: '0.17.0'
   collection: '1.16.0'
   equatable: '2.0.3'
   logger: '1.1.0'
-  uuid: '3.0.6'
+  uuid: '3.0.7'
   # Firebase
   firebase_core: '1.16.0'
   firebase_crashlytics: '2.7.2'
@@ -47,14 +47,14 @@ dependencies:
   # UI
   google_fonts: '2.3.2'
   # Analytics
-  matomo:
-    git:
-      url: https://github.com/BonnetM/dart-matomo.git
-      ref: feat/add-outlink-support
+  matomo_tracker: '2.0.0'
 
   encrypt: '5.0.1'
   smooth_page_indicator: '1.0.0+2'
   in_app_review: '2.0.4'
+
+dependency_overrides:
+  ffi: '2.0.1'
 
 dev_dependencies:
   flutter_test:

--- a/test/doubles/dummies.dart
+++ b/test/doubles/dummies.dart
@@ -2,7 +2,6 @@ import 'package:flutter_appauth/flutter_appauth.dart';
 import 'package:flutter_secure_storage/flutter_secure_storage.dart';
 import 'package:http/http.dart';
 import 'package:http/testing.dart';
-import 'package:matomo/matomo.dart';
 import 'package:pass_emploi_app/auth/auth_wrapper.dart';
 import 'package:pass_emploi_app/auth/authenticator.dart';
 import 'package:pass_emploi_app/auth/firebase_auth_wrapper.dart';
@@ -315,15 +314,6 @@ class DummyModifyDemarcheRepository extends UpdateDemarcheRepository {
     DateTime? dateDebut,
   ) async {
     return null;
-  }
-}
-
-class DummyMatomoTracker extends MatomoTracker {
-  DummyMatomoTracker() : super.internal();
-
-  @override
-  void setOptOut(bool optout) {
-    // Do nothing
   }
 }
 

--- a/test/doubles/dummy_matomo_tracker.dart
+++ b/test/doubles/dummy_matomo_tracker.dart
@@ -1,0 +1,184 @@
+import 'dart:async';
+import 'dart:collection';
+import 'dart:ui';
+
+import 'package:flutter/src/widgets/framework.dart';
+import 'package:matomo_tracker/matomo_tracker.dart';
+import 'package:matomo_tracker/src/logger.dart';
+import 'package:matomo_tracker/src/matomo_event.dart';
+import 'package:matomo_tracker/src/session.dart';
+import 'package:package_info_plus/package_info_plus.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+class DummyMatomoTracker implements MatomoTracker {
+  @override
+  late String contentBase;
+
+  @override
+  String? currentScreenId;
+
+  @override
+  late bool initialized;
+
+  @override
+  late Size screenResolution;
+
+  @override
+  late Session session;
+
+  @override
+  late int siteId;
+
+  @override
+  late Timer timer;
+
+  @override
+  late String url;
+
+  @override
+  String? userAgent;
+
+  @override
+  void clear() {
+    // Do nothing
+  }
+
+  @override
+  void dispatchEvents() {
+    // Do nothing
+  }
+
+  @override
+  void dispose() {
+    // Do nothing
+  }
+
+  @override
+  String? get getAuthToken => null;
+
+  @override
+  bool getOptOut() => false;
+
+  @override
+  Logger get log => throw UnimplementedError();
+
+  @override
+  bool? get optOut => false;
+
+  @override
+  void pause() {
+    // Do nothing
+  }
+
+  @override
+  // Do nothing
+  Queue<MatomoEvent> get queue => throw UnimplementedError();
+
+  @override
+  void resume() {
+    // Do nothing
+  }
+
+  @override
+  Future<void> setOptOut({required bool optout}) {
+    // Do nothing
+    throw UnimplementedError();
+  }
+
+  @override
+  void trackCartUpdate(
+    List<TrackingOrderItem>? trackingOrderItems,
+    num? subTotal,
+    num? taxAmount,
+    num? shippingCost,
+    num? discountAmount, {
+    Map<String, String>? dimensions,
+  }) {
+    // Do nothing
+  }
+
+  @override
+  void trackDimensions(Map<String, String> dimensions) {
+    // Do nothing
+  }
+
+  @override
+  void trackEvent({
+    required String eventCategory,
+    required String action,
+    String? eventName,
+    int? eventValue,
+    Map<String, String>? dimensions,
+  }) {
+    // Do nothing
+  }
+
+  @override
+  void trackGoal(int goalId, {double? revenue, Map<String, String>? dimensions}) {
+    // Do nothing
+  }
+
+  @override
+  void trackOrder(
+    String? orderId,
+    List<TrackingOrderItem>? trackingOrderItems,
+    num? revenue,
+    num? subTotal,
+    num? taxAmount,
+    num? shippingCost,
+    num? discountAmount, {
+    Map<String, String>? dimensions,
+  }) {
+    // Do nothing
+  }
+
+  @override
+  void trackOutlink(String? link, {Map<String, String>? dimensions}) {
+    // Do nothing
+  }
+
+  @override
+  void trackScreen(BuildContext context,
+      {required String eventName, String? currentScreenId, String? path, Map<String, String>? dimensions}) {
+    // Do nothing
+  }
+
+  @override
+  void trackScreenWithName({
+    required String widgetName,
+    required String eventName,
+    String? currentScreenId,
+    String? path,
+    Map<String, String>? dimensions,
+  }) {
+    // Do nothing
+  }
+
+  @override
+  void trackSearch(
+      {required String searchKeyword, String? searchCategory, int? searchCount, Map<String, String>? dimensions}) {
+    // Do nothing
+  }
+
+  @override
+  Visitor get visitor => throw UnimplementedError();
+
+  @override
+  Future<void> initialize({
+    required int siteId,
+    required String url,
+    String? visitorId,
+    String? contentBaseUrl,
+    int dequeueInterval = 10,
+    String? tokenAuth,
+    SharedPreferences? prefs,
+    PackageInfo? packageInfo,
+  }) async {
+    // Do nothing
+  }
+
+  @override
+  void setVisitorUserId(String? userId) {
+    // Do nothing
+  }
+}

--- a/test/doubles/dummy_matomo_tracker.dart
+++ b/test/doubles/dummy_matomo_tracker.dart
@@ -8,9 +8,10 @@ import 'package:matomo_tracker/src/logger.dart';
 import 'package:matomo_tracker/src/matomo_event.dart';
 import 'package:matomo_tracker/src/session.dart';
 import 'package:package_info_plus/package_info_plus.dart';
+import 'package:pass_emploi_app/utils/pass_emploi_matomo_tracker.dart';
 import 'package:shared_preferences/shared_preferences.dart';
 
-class DummyMatomoTracker implements MatomoTracker {
+class DummyMatomoTracker implements PassEmploiMatomoTracker {
   @override
   late String contentBase;
 
@@ -39,6 +40,27 @@ class DummyMatomoTracker implements MatomoTracker {
   String? userAgent;
 
   @override
+  String? get getAuthToken => null;
+
+  @override
+  bool getOptOut() => false;
+
+  @override
+  Logger get log => throw UnimplementedError();
+
+  @override
+  bool? get optOut => false;
+
+  @override
+  Queue<MatomoEvent> get queue => throw UnimplementedError();
+
+  @override
+  Visitor get visitor => throw UnimplementedError();
+
+  @override
+  Function(String screen)? onTrackScreen;
+
+  @override
   void clear() {
     // Do nothing
   }
@@ -54,25 +76,9 @@ class DummyMatomoTracker implements MatomoTracker {
   }
 
   @override
-  String? get getAuthToken => null;
-
-  @override
-  bool getOptOut() => false;
-
-  @override
-  Logger get log => throw UnimplementedError();
-
-  @override
-  bool? get optOut => false;
-
-  @override
   void pause() {
     // Do nothing
   }
-
-  @override
-  // Do nothing
-  Queue<MatomoEvent> get queue => throw UnimplementedError();
 
   @override
   void resume() {
@@ -80,9 +86,8 @@ class DummyMatomoTracker implements MatomoTracker {
   }
 
   @override
-  Future<void> setOptOut({required bool optout}) {
+  Future<void> setOptOut({required bool optout}) async {
     // Do nothing
-    throw UnimplementedError();
   }
 
   @override
@@ -159,9 +164,6 @@ class DummyMatomoTracker implements MatomoTracker {
       {required String searchKeyword, String? searchCategory, int? searchCount, Map<String, String>? dimensions}) {
     // Do nothing
   }
-
-  @override
-  Visitor get visitor => throw UnimplementedError();
 
   @override
   Future<void> initialize({

--- a/test/doubles/dummy_matomo_tracker.dart
+++ b/test/doubles/dummy_matomo_tracker.dart
@@ -143,8 +143,13 @@ class DummyMatomoTracker implements PassEmploiMatomoTracker {
   }
 
   @override
-  void trackScreen(BuildContext context,
-      {required String eventName, String? currentScreenId, String? path, Map<String, String>? dimensions}) {
+  void trackScreen(
+    BuildContext context, {
+    required String eventName,
+    String? currentScreenId,
+    String? path,
+    Map<String, String>? dimensions,
+  }) {
     // Do nothing
   }
 

--- a/test/utils/test_setup.dart
+++ b/test/utils/test_setup.dart
@@ -1,4 +1,4 @@
-import 'package:matomo/matomo.dart';
+import 'package:matomo_tracker/matomo_tracker.dart';
 import 'package:pass_emploi_app/auth/authenticator.dart';
 import 'package:pass_emploi_app/auth/firebase_auth_wrapper.dart';
 import 'package:pass_emploi_app/crashlytics/crashlytics.dart';
@@ -47,6 +47,7 @@ import 'package:pass_emploi_app/repositories/tutorial_repository.dart';
 import 'package:redux/redux.dart';
 
 import '../doubles/dummies.dart';
+import '../doubles/dummy_matomo_tracker.dart';
 
 class TestStoreFactory {
   Authenticator authenticator = DummyAuthenticator();

--- a/test/utils/test_setup.dart
+++ b/test/utils/test_setup.dart
@@ -1,4 +1,3 @@
-import 'package:matomo_tracker/matomo_tracker.dart';
 import 'package:pass_emploi_app/auth/authenticator.dart';
 import 'package:pass_emploi_app/auth/firebase_auth_wrapper.dart';
 import 'package:pass_emploi_app/crashlytics/crashlytics.dart';
@@ -43,6 +42,7 @@ import 'package:pass_emploi_app/repositories/suggestions_recherche_repository.da
 import 'package:pass_emploi_app/repositories/suppression_compte_repository.dart';
 import 'package:pass_emploi_app/repositories/tracking_analytics/tracking_event_repository.dart';
 import 'package:pass_emploi_app/repositories/tutorial_repository.dart';
+import 'package:pass_emploi_app/utils/pass_emploi_matomo_tracker.dart';
 /*AUTOGENERATE-REDUX-TEST-SETUP-REPOSITORY-IMPORT*/
 import 'package:redux/redux.dart';
 
@@ -81,7 +81,7 @@ class TestStoreFactory {
   SuppressionCompteRepository suppressionCompteRepository = DummySuppressionCompteRepository();
   CampagneRepository campagneRepository = DummyCampagneRepository();
   ModeDemoRepository demoRepository = ModeDemoRepository();
-  MatomoTracker matomoTracker = DummyMatomoTracker();
+  PassEmploiMatomoTracker matomoTracker = DummyMatomoTracker();
   UpdateDemarcheRepository updateDemarcheRepository = DummyUpdateDemarcheRepository();
   CreateDemarcheRepository createDemarcheRepository = DummySuccessCreateDemarcheRepository();
   SearchDemarcheRepository searchDemarcheRepository = DummyDemarcheDuReferentielRepository();


### PR DESCRIPTION
Alors, à discuter de l'intérêt de cette PR…
Le gros + : on ne dépend plus d'un répo privé, donc on peut faire des MAJ sans soucis.
Dans les moins : beaucoup de MAJ/changement de libs.
Je m'explique, suite à un enchainement de lib tirées, j'ai du faire un gros update de plusieurs librairies (même des `compileSdkVersion` et `targetSdkVersion` Android, à voir si ça ne pête pas la CI 🤣). Et j'ai même du remplacer la lib `open_file` par `open_filex` qui comme sa page pub.dev l'indique est un fork maitenu (contrairement à la lib originale qui n'a plus d'évolution depuis 18 mois), et qui règle [plusieurs soucis](https://pub.dev/packages/open_filex), dont la permission Android qui nous a couté le refus du store ET surtout une dépendances à `ffi` trop vieille qui nous obligeait à tweeker notre `pubspec.yaml`.

Bref, si on merge, il faudra dire aux PO de faire une non reg sur les pièces jointes, et accessoirement les notifs, car la lib `flutter_local_notification` que j'ai du mettre à jour avait des breaking changes.

Après pour en revenir à la feature, dans la nouvelle lib Matomo, je n'ai plus pu faire ma bidouille pour catcher les logs comme avant, du coup, j'ai fait un décorateur un peu fastidieux mais qui fait le job. Et ça m'a permis grâce à notre écran de debug log de voir avec un téléphone sur `develop` et un autre sur cette branche qu'a priori ça passe toujours.

Long story short : à vos retours !