### PR TITLE
fix(1472): Fix wrong calls to Matomo

### DIFF
--- a/lib/analytics/analytics_constants.dart
+++ b/lib/analytics/analytics_constants.dart
@@ -51,7 +51,6 @@ class AnalyticsScreenNames {
 
   static String rechercheModifieeResultats(String type) => "recherche/$type/search_results?update=true";
 
-  static const emploiResults = "recherche/emploi/search_results";
   static const emploiDetails = "recherche/emploi/detail";
   static const emploiFiltres = "recherche/emploi/search_results/filters";
   static const emploiCreateAlert = "/saved_search/emploi/create";
@@ -63,13 +62,11 @@ class AnalyticsScreenNames {
   static const alternanceFiltres = "recherche/alternance/search_results/filters";
   static const alternanceCreateAlert = "/saved_search/alternance/create";
 
-  static const immersionResults = "recherche/immersion/search_results";
   static const immersionDetails = "recherche/immersion/detail";
   static const immersionContact = "recherche/immersion/detail/contact";
   static const immersionFiltres = "recherche/immersion/search_results/filters";
   static const immersionCreateAlert = "/saved_search/immersion/create";
 
-  static const serviceCiviqueResults = "recherche/service_civique/search_results";
   static const serviceCiviqueDetail = "recherche/service_civique/detail";
   static const serviceCiviqueFiltres = "recherche/service_civique/search_results/filters";
   static const serviceCiviqueCreateAlert = "/saved_search/service_civique/create";

--- a/lib/analytics/tracker.dart
+++ b/lib/analytics/tracker.dart
@@ -45,6 +45,6 @@ class _TrackerState extends State<Tracker> with RouteAware {
   }
 
   void _track() {
-    PassEmploiMatomoTracker.instance.trackScreen(context, eventName: widget.tracking);
+    PassEmploiMatomoTracker.instance.trackScreen(widget.tracking);
   }
 }

--- a/lib/pages/cej_information_page.dart
+++ b/lib/pages/cej_information_page.dart
@@ -32,10 +32,7 @@ class _CejInformationPageState extends State<CejInformationPage> {
       final _controllerPage = _controller.page?.floor();
       if (_controllerPage != null && _controllerPage != _displayedPage) {
         _displayedPage = _controllerPage;
-        PassEmploiMatomoTracker.instance.trackScreen(
-          context,
-          eventName: AnalyticsScreenNames.cejInformationPage(_controllerPage + 1),
-        );
+        PassEmploiMatomoTracker.instance.trackScreen(AnalyticsScreenNames.cejInformationPage(_controllerPage + 1));
       }
     });
     super.initState();

--- a/lib/pages/chat_partage_page.dart
+++ b/lib/pages/chat_partage_page.dart
@@ -149,7 +149,7 @@ class _ChatPartagePageState extends State<ChatPartagePage> {
       case DisplayState.LOADING:
         return;
       case DisplayState.CONTENT:
-        PassEmploiMatomoTracker.instance.trackScreen(context, eventName: viewModel.snackbarSuccessTracking);
+        PassEmploiMatomoTracker.instance.trackScreen(viewModel.snackbarSuccessTracking);
         showSuccessfulSnackBar(context, viewModel.snackbarSuccessText);
         viewModel.snackbarDisplayed();
         Navigator.pop(context);

--- a/lib/pages/demarche/create_demarche_step3_page.dart
+++ b/lib/pages/demarche/create_demarche_step3_page.dart
@@ -104,7 +104,7 @@ class _CreateDemarcheStep3PageState extends State<CreateDemarcheStep3Page> {
   void _onDidChange(CreateDemarcheStep3ViewModel? oldVm, CreateDemarcheStep3ViewModel newVm) {
     final creationState = newVm.demarcheCreationState;
     if (creationState is DemarcheCreationSuccessState) {
-      PassEmploiMatomoTracker.instance.trackScreen(context, eventName: AnalyticsScreenNames.searchDemarcheStep3Success);
+      PassEmploiMatomoTracker.instance.trackScreen(AnalyticsScreenNames.searchDemarcheStep3Success);
       Navigator.pop(context, creationState.demarcheCreatedId);
     }
   }

--- a/lib/pages/offre_favoris_tab_page.dart
+++ b/lib/pages/offre_favoris_tab_page.dart
@@ -198,7 +198,7 @@ class _OffreFavorisTabPageState extends State<OffreFavorisTabPage> {
         tracking = AnalyticsScreenNames.offreFavorisListFilterServiceCivique;
         break;
     }
-    PassEmploiMatomoTracker.instance.trackScreen(context, eventName: tracking);
+    PassEmploiMatomoTracker.instance.trackScreen(tracking);
   }
 }
 

--- a/lib/pages/recherche/recherche_home_page.dart
+++ b/lib/pages/recherche/recherche_home_page.dart
@@ -33,10 +33,7 @@ class RechercheHomePage extends StatelessWidget {
               SizedBox(height: Margins.spacing_base),
               VoirSuggestionsRechercheBandeau(
                 onTapShowSuggestions: () {
-                  PassEmploiMatomoTracker.instance.trackScreen(
-                    context,
-                    eventName: AnalyticsScreenNames.rechercheSuggestionsListe,
-                  );
+                  PassEmploiMatomoTracker.instance.trackScreen(AnalyticsScreenNames.rechercheSuggestionsListe);
                   Navigator.push(context, SuggestionsRechercheListPage.materialPageRoute());
                 },
               ),

--- a/lib/pages/rendezvous/rendezvous_details_page.dart
+++ b/lib/pages/rendezvous/rendezvous_details_page.dart
@@ -63,7 +63,7 @@ class RendezvousDetailsPage extends StatelessWidget {
       builder: _scaffold,
       onInitialBuild: (viewModel) {
         if (viewModel.trackingPageName != null) {
-          PassEmploiMatomoTracker.instance.trackScreen(context, eventName: viewModel.trackingPageName!);
+          PassEmploiMatomoTracker.instance.trackScreen(viewModel.trackingPageName!);
         }
       },
       onDispose: (store) {

--- a/lib/pages/saved_search_tab_page.dart
+++ b/lib/pages/saved_search_tab_page.dart
@@ -254,6 +254,6 @@ class _SavedSearchTabPageState extends State<SavedSearchTabPage> {
         tracking = AnalyticsScreenNames.savedSearchListFilterServiceCivique;
         break;
     }
-    PassEmploiMatomoTracker.instance.trackScreen(context, eventName: tracking);
+    PassEmploiMatomoTracker.instance.trackScreen(tracking);
   }
 }

--- a/lib/pages/suppression_compte_page.dart
+++ b/lib/pages/suppression_compte_page.dart
@@ -115,19 +115,13 @@ class _DeleteAccountButton extends StatelessWidget {
     await showDialog(
       context: context,
       builder: (_) {
-        PassEmploiMatomoTracker.instance.trackScreenWithName(
-          widgetName: AnalyticsScreenNames.suppressionAccount,
-          eventName: AnalyticsActionNames.suppressionAccountConfirmation,
-        );
+        PassEmploiMatomoTracker.instance.trackScreen(AnalyticsActionNames.suppressionAccountConfirmation);
         return DeleteAlertDialog();
       },
     ).then((result) {
       if (result == true) {
         showSuccessfulSnackBar(context, Strings.accountDeletionSuccess);
-        PassEmploiMatomoTracker.instance.trackScreenWithName(
-          widgetName: AnalyticsScreenNames.suppressionAccount,
-          eventName: AnalyticsActionNames.suppressionAccountSucceded,
-        );
+        PassEmploiMatomoTracker.instance.trackScreen(AnalyticsActionNames.suppressionAccountSucceded);
       } else if (result == false) {
         showFailedSnackBar(context, Strings.savedSearchDeleteError);
       }

--- a/lib/pages/tutorial_page.dart
+++ b/lib/pages/tutorial_page.dart
@@ -94,16 +94,10 @@ class _TutorialPageState extends State<TutorialPage> {
                           duration: Duration(milliseconds: 600),
                           curve: Curves.linearToEaseOut,
                         );
-                        PassEmploiMatomoTracker.instance.trackScreenWithName(
-                          widgetName: AnalyticsScreenNames.tutorialPage,
-                          eventName: AnalyticsActionNames.continueTutorial,
-                        );
+                        PassEmploiMatomoTracker.instance.trackScreen(AnalyticsActionNames.continueTutorial);
                       } else {
                         viewModel.onDone();
-                        PassEmploiMatomoTracker.instance.trackScreenWithName(
-                          widgetName: AnalyticsScreenNames.tutorialPage,
-                          eventName: AnalyticsActionNames.doneTutorial,
-                        );
+                        PassEmploiMatomoTracker.instance.trackScreen(AnalyticsActionNames.doneTutorial);
                       }
                     },
                   ),
@@ -155,11 +149,8 @@ class _SkipButton extends StatelessWidget {
           InkWell(
             onTap: active
                 ? () {
-                    viewModel.onDone();
-                    PassEmploiMatomoTracker.instance.trackScreenWithName(
-                      widgetName: AnalyticsScreenNames.tutorialPage,
-                      eventName: AnalyticsActionNames.skipTutorial,
-                    );
+              viewModel.onDone();
+                    PassEmploiMatomoTracker.instance.trackScreen(AnalyticsActionNames.skipTutorial);
                   }
                 : null,
             child: Padding(
@@ -295,10 +286,7 @@ class _DelayedButton extends StatelessWidget {
           child: InkWell(
             onTap: () {
               viewModel.onDelay();
-              PassEmploiMatomoTracker.instance.trackScreenWithName(
-                widgetName: AnalyticsScreenNames.tutorialPage,
-                eventName: AnalyticsActionNames.delayedTutorial,
-              );
+              PassEmploiMatomoTracker.instance.trackScreen(AnalyticsActionNames.delayedTutorial);
             },
             child: Wrap(
               crossAxisAlignment: WrapCrossAlignment.end,

--- a/lib/pages/user_action/action_commentaires_page.dart
+++ b/lib/pages/user_action/action_commentaires_page.dart
@@ -197,10 +197,7 @@ class _CreateCommentaireWidgetState extends State<_CreateCommentaireWidget> {
               onPressed: () {
                 if (_controller.value.text.isNotEmpty && !_loading()) {
                   widget.viewModel.onSend(_controller.value.text);
-                  PassEmploiMatomoTracker.instance.trackScreenWithName(
-                    widgetName: AnalyticsScreenNames.actionCommentsPage,
-                    eventName: AnalyticsActionNames.sendComment,
-                  );
+                  PassEmploiMatomoTracker.instance.trackScreen(AnalyticsActionNames.sendComment);
                   _controller.clear();
                 }
               },

--- a/lib/pages/user_action/user_action_detail_page.dart
+++ b/lib/pages/user_action/user_action_detail_page.dart
@@ -151,10 +151,7 @@ class _ActionDetailPageState extends State<UserActionDetailPage> {
   void _onDeleteAction(UserActionDetailsViewModel viewModel) {
     if (viewModel.deleteDisplayState != DeleteDisplayState.SHOW_LOADING) {
       viewModel.onDelete(viewModel.id);
-      PassEmploiMatomoTracker.instance.trackScreenWithName(
-        widgetName: AnalyticsScreenNames.userActionDetails,
-        eventName: AnalyticsActionNames.deleteUserAction,
-      );
+      PassEmploiMatomoTracker.instance.trackScreen(AnalyticsActionNames.deleteUserAction);
     }
   }
 
@@ -202,10 +199,7 @@ class _ActionDetailPageState extends State<UserActionDetailPage> {
   }
 
   void _trackSuccessfulUpdate() {
-    PassEmploiMatomoTracker.instance.trackScreenWithName(
-      widgetName: AnalyticsScreenNames.userActionDetails,
-      eventName: AnalyticsScreenNames.updateUserAction,
-    );
+    PassEmploiMatomoTracker.instance.trackScreen(AnalyticsScreenNames.updateUserAction);
   }
 }
 
@@ -383,10 +377,7 @@ class _CommentCard extends StatelessWidget {
   }
 
   void _onCommentClick(BuildContext context, String actionId, String actionTitle) {
-    PassEmploiMatomoTracker.instance.trackScreenWithName(
-      widgetName: AnalyticsScreenNames.userActionDetails,
-      eventName: AnalyticsActionNames.accessToActionComments,
-    );
+    PassEmploiMatomoTracker.instance.trackScreen(AnalyticsActionNames.accessToActionComments);
     Navigator.push(
       context,
       MaterialPageRoute(builder: (context) => ActionCommentairesPage(actionId: actionId, actionTitle: actionTitle)),

--- a/lib/utils/pass_emploi_matomo_tracker.dart
+++ b/lib/utils/pass_emploi_matomo_tracker.dart
@@ -1,6 +1,5 @@
 import 'dart:async';
 
-import 'package:flutter/material.dart';
 import 'package:matomo_tracker/matomo_tracker.dart';
 import 'package:package_info_plus/package_info_plus.dart';
 import 'package:shared_preferences/shared_preferences.dart';
@@ -42,57 +41,27 @@ class PassEmploiMatomoTracker {
     _dimensions = dimensions.map((key, value) => MapEntry('dimension$key', Uri.encodeComponent(value)));
   }
 
-  void trackEvent({
-    required String eventCategory,
-    required String action,
-    String? eventName,
-    int? eventValue,
-    Map<String, String>? dimensions,
-  }) {
+  void trackScreen(String widgetName) {
+    _decorated.trackScreenWithName(
+      widgetName: widgetName,
+      eventName: widgetName,
+      path: widgetName,
+      dimensions: _dimensions,
+    );
+    onTrackScreen?.call(widgetName);
+  }
+
+  void trackEvent({required String eventCategory, required String action, String? eventName, int? eventValue}) {
     _decorated.trackEvent(
       eventCategory: eventCategory,
       action: action,
       eventName: eventName,
       eventValue: eventValue,
-      dimensions: dimensions ?? _dimensions,
+      dimensions: _dimensions,
     );
   }
 
-  void trackOutlink(String? link, {Map<String, String>? dimensions}) {
-    _decorated.trackOutlink(link, dimensions: dimensions);
-  }
-
-  void trackScreen(
-    BuildContext context, {
-    required String eventName,
-    String? currentScreenId,
-    String? path,
-    Map<String, String>? dimensions,
-  }) {
-    _decorated.trackScreen(
-      context,
-      eventName: eventName,
-      currentScreenId: currentScreenId,
-      path: path,
-      dimensions: dimensions ?? _dimensions,
-    );
-    onTrackScreen?.call(eventName);
-  }
-
-  void trackScreenWithName({
-    required String widgetName,
-    required String eventName,
-    String? currentScreenId,
-    String? path,
-    Map<String, String>? dimensions,
-  }) {
-    _decorated.trackScreenWithName(
-      widgetName: widgetName,
-      eventName: eventName,
-      currentScreenId: currentScreenId,
-      path: path,
-      dimensions: dimensions ?? _dimensions,
-    );
-    onTrackScreen?.call('$eventName in $widgetName');
+  void trackOutlink(String? link) {
+    _decorated.trackOutlink(link, dimensions: _dimensions);
   }
 }

--- a/lib/widgets/bottom_sheets/immersion_bottom_sheet_form.dart
+++ b/lib/widgets/bottom_sheets/immersion_bottom_sheet_form.dart
@@ -68,10 +68,7 @@ class _ImmersionBottomSheetFormState extends State<ImmersionBottomSheetForm> {
             onPressed: (_isFormValid())
                 ? () {
                     viewModel.createSavedSearch(searchTitle!);
-                    PassEmploiMatomoTracker.instance.trackScreenWithName(
-                      widgetName: AnalyticsScreenNames.immersionCreateAlert,
-                      eventName: AnalyticsActionNames.createSavedSearchImmersion,
-                    );
+                    PassEmploiMatomoTracker.instance.trackScreen(AnalyticsActionNames.createSavedSearchImmersion);
                   }
                 : null,
           ),

--- a/lib/widgets/bottom_sheets/offre_emploi_bottom_sheet_form.dart
+++ b/lib/widgets/bottom_sheets/offre_emploi_bottom_sheet_form.dart
@@ -70,11 +70,8 @@ class _OffreEmploiBottomSheetFormState extends State<OffreEmploiBottomSheetForm>
             onPressed: (_isFormValid())
                 ? () {
                     viewModel.createSavedSearch(searchTitle!);
-                    PassEmploiMatomoTracker.instance.trackScreenWithName(
-                      eventName: widget.onlyAlternance
-                          ? AnalyticsScreenNames.alternanceCreateAlert
-                          : AnalyticsScreenNames.emploiCreateAlert,
-                      widgetName: widget.onlyAlternance
+                    PassEmploiMatomoTracker.instance.trackScreen(
+                      widget.onlyAlternance
                           ? AnalyticsActionNames.createSavedSearchAlternance
                           : AnalyticsActionNames.createSavedSearchEmploi,
                     );

--- a/lib/widgets/bottom_sheets/rating_bottom_sheet.dart
+++ b/lib/widgets/bottom_sheets/rating_bottom_sheet.dart
@@ -82,7 +82,9 @@ class RatingBottomSheet extends StatelessWidget {
   void _ratingDone(BuildContext context, RatingViewModel viewModel, bool isPositive) {
     viewModel.onDone();
     Navigator.pop(context);
-    _matomoTracking(isPositive ? AnalyticsActionNames.positiveRating : AnalyticsActionNames.negativeRating);
+    PassEmploiMatomoTracker.instance.trackScreen(
+      isPositive ? AnalyticsActionNames.positiveRating : AnalyticsActionNames.negativeRating,
+    );
   }
 }
 
@@ -99,7 +101,7 @@ class _RatingHeader extends StatelessWidget {
         IconButton(
           onPressed: () {
             onDismiss();
-            _matomoTracking(AnalyticsActionNames.skipRating);
+            PassEmploiMatomoTracker.instance.trackScreen(AnalyticsActionNames.skipRating);
             Navigator.pop(context);
           },
           tooltip: Strings.close,
@@ -114,8 +116,4 @@ class _RatingHeader extends StatelessWidget {
       ],
     );
   }
-}
-
-void _matomoTracking(String action) {
-  PassEmploiMatomoTracker.instance.trackScreenWithName(widgetName: AnalyticsScreenNames.ratingPage, eventName: action);
 }

--- a/lib/widgets/bottom_sheets/service_civique_bottom_sheet_form.dart
+++ b/lib/widgets/bottom_sheets/service_civique_bottom_sheet_form.dart
@@ -68,10 +68,7 @@ class _ServiceCiviqueBottomSheetFormState extends State<ServiceCiviqueBottomShee
             onPressed: (_isFormValid())
                 ? () {
                     viewModel.createSavedSearch(searchTitle!);
-                    PassEmploiMatomoTracker.instance.trackScreenWithName(
-                      widgetName: AnalyticsScreenNames.serviceCiviqueCreateAlert,
-                      eventName: AnalyticsActionNames.createSavedSearchServiceCivique,
-                    );
+                    PassEmploiMatomoTracker.instance.trackScreen(AnalyticsActionNames.createSavedSearchServiceCivique);
                   }
                 : null,
           ),

--- a/lib/widgets/buttons/delete_favori_button.dart
+++ b/lib/widgets/buttons/delete_favori_button.dart
@@ -25,7 +25,7 @@ class DeleteFavoriButton<T> extends StatelessWidget {
           onPressed: vm.withLoading
               ? null
               : () {
-            vm.update(FavoriStatus.removed);
+                  vm.update(FavoriStatus.removed);
                   _tracking();
                 },
         );
@@ -46,9 +46,6 @@ class DeleteFavoriButton<T> extends StatelessWidget {
 
   void _tracking() {
     final widgetName = FavoriHeartAnalyticsHelper().getAnalyticsWidgetName(from, false);
-    final eventName = FavoriHeartAnalyticsHelper().getAnalyticsEventName(from);
-    if (widgetName != null && eventName != null) {
-      PassEmploiMatomoTracker.instance.trackScreenWithName(widgetName: widgetName, eventName: eventName);
-    }
+    if (widgetName != null) PassEmploiMatomoTracker.instance.trackScreen(widgetName);
   }
 }

--- a/lib/widgets/dialogs/saved_search_delete_dialog.dart
+++ b/lib/widgets/dialogs/saved_search_delete_dialog.dart
@@ -59,8 +59,7 @@ class SavedSearchDeleteDialog extends StatelessWidget {
         builder: (context, viewModel) => _alertDialog(context, viewModel),
         onWillChange: (_, viewModel) {
           if (viewModel.displayState == SavedSearchDeleteDisplayState.SUCCESS) {
-            PassEmploiMatomoTracker.instance
-                .trackScreenWithName(widgetName: _screenName(type), eventName: _actionName(type));
+            PassEmploiMatomoTracker.instance.trackScreen(_actionName(type));
             Navigator.pop(context, true);
           }
         },

--- a/lib/widgets/favori_heart.dart
+++ b/lib/widgets/favori_heart.dart
@@ -68,10 +68,7 @@ class FavoriHeart<T> extends StatelessWidget {
   void _sendTracking(bool isFavori) {
     final newFavoriStatus = !isFavori;
     final widgetName = FavoriHeartAnalyticsHelper().getAnalyticsWidgetName(from, newFavoriStatus);
-    final eventName = FavoriHeartAnalyticsHelper().getAnalyticsEventName(from);
-    if (widgetName != null && eventName != null) {
-      PassEmploiMatomoTracker.instance.trackScreenWithName(widgetName: widgetName, eventName: eventName);
-    }
+    if (widgetName != null) PassEmploiMatomoTracker.instance.trackScreen(widgetName);
   }
 }
 
@@ -96,29 +93,6 @@ class FavoriHeartAnalyticsHelper {
         return AnalyticsActionNames.serviceCiviqueDetailUpdateFavori(isFavori);
       case OffrePage.offreFavoris:
         return AnalyticsActionNames.offreFavoriUpdateFavori(isFavori);
-    }
-  }
-
-  String? getAnalyticsEventName(OffrePage from) {
-    switch (from) {
-      case OffrePage.emploiResults:
-        return AnalyticsScreenNames.emploiResults;
-      case OffrePage.emploiDetails:
-        return AnalyticsScreenNames.emploiDetails;
-      case OffrePage.alternanceResults:
-        return AnalyticsScreenNames.alternanceResults;
-      case OffrePage.alternanceDetails:
-        return AnalyticsScreenNames.alternanceDetails;
-      case OffrePage.immersionResults:
-        return AnalyticsScreenNames.immersionResults;
-      case OffrePage.immersionDetails:
-        return AnalyticsScreenNames.immersionDetails;
-      case OffrePage.serviceCiviqueResults:
-        return AnalyticsScreenNames.serviceCiviqueResults;
-      case OffrePage.serviceCiviqueDetails:
-        return AnalyticsScreenNames.serviceCiviqueDetail;
-      case OffrePage.offreFavoris:
-        return AnalyticsScreenNames.offreFavorisList;
     }
   }
 }

--- a/lib/widgets/recherche/bloc_resultat_recherche.dart
+++ b/lib/widgets/recherche/bloc_resultat_recherche.dart
@@ -85,8 +85,7 @@ class _BlocResultatRechercheState<Result> extends State<BlocResultatRecherche<Re
       _lastNumberSearchAnalyticSent = _numberOfSearchSent;
 
       PassEmploiMatomoTracker.instance.trackScreen(
-        context,
-        eventName: _numberOfSearchSent == 0
+        _numberOfSearchSent == 0
             ? AnalyticsScreenNames.rechercheInitialeResultats(widget.analyticsType)
             : AnalyticsScreenNames.rechercheModifieeResultats(widget.analyticsType),
       );

--- a/lib/widgets/recherche/resultat_recherche_contenu.dart
+++ b/lib/widgets/recherche/resultat_recherche_contenu.dart
@@ -76,8 +76,7 @@ class ResultatRechercheContenuState<Result> extends State<ResultatRechercheConte
   void _onLoadMorePressed(BuildContext context) {
     widget.viewModel.onLoadMore();
     PassEmploiMatomoTracker.instance.trackScreen(
-      context,
-      eventName: AnalyticsScreenNames.rechercheAfficherPlusOffres(widget.analyticsType),
+      AnalyticsScreenNames.rechercheAfficherPlusOffres(widget.analyticsType),
     );
   }
 

--- a/lib/widgets/snack_bar/rating_snack_bar.dart
+++ b/lib/widgets/snack_bar/rating_snack_bar.dart
@@ -53,10 +53,7 @@ class _DismissSnackBar extends StatelessWidget {
   void _onDismiss(BuildContext context, RatingViewModel viewModel) {
     viewModel.onDone();
     snackbarKey.currentState?.hideCurrentSnackBar();
-    PassEmploiMatomoTracker.instance.trackScreenWithName(
-      widgetName: AnalyticsScreenNames.ratingPage,
-      eventName: AnalyticsActionNames.skipRating,
-    );
+    PassEmploiMatomoTracker.instance.trackScreen(AnalyticsActionNames.skipRating);
   }
 }
 

--- a/test/doubles/dummy_matomo_tracker.dart
+++ b/test/doubles/dummy_matomo_tracker.dart
@@ -1,6 +1,5 @@
 import 'dart:async';
 
-import 'package:flutter/src/widgets/framework.dart';
 import 'package:package_info_plus/package_info_plus.dart';
 import 'package:pass_emploi_app/utils/pass_emploi_matomo_tracker.dart';
 import 'package:shared_preferences/shared_preferences.dart';
@@ -34,40 +33,17 @@ class DummyMatomoTracker implements PassEmploiMatomoTracker {
   }
 
   @override
-  void trackEvent({
-    required String eventCategory,
-    required String action,
-    String? eventName,
-    int? eventValue,
-    Map<String, String>? dimensions,
-  }) {
+  void trackScreen(String widgetName) {
     // Do nothing
   }
 
   @override
-  void trackOutlink(String? link, {Map<String, String>? dimensions}) {
+  void trackEvent({required String eventCategory, required String action, String? eventName, int? eventValue}) {
     // Do nothing
   }
 
   @override
-  void trackScreen(
-    BuildContext context, {
-    required String eventName,
-    String? currentScreenId,
-    String? path,
-    Map<String, String>? dimensions,
-  }) {
-    // Do nothing
-  }
-
-  @override
-  void trackScreenWithName({
-    required String widgetName,
-    required String eventName,
-    String? currentScreenId,
-    String? path,
-    Map<String, String>? dimensions,
-  }) {
+  void trackOutlink(String? link) {
     // Do nothing
   }
 }

--- a/test/widgets/favori_heart_test.dart
+++ b/test/widgets/favori_heart_test.dart
@@ -29,9 +29,15 @@ void main() {
     assertAnalyticsWidgetName(OffrePage.alternanceDetails, false, "/solutions/alternance/detail?favori=false");
 
     assertAnalyticsWidgetName(
-        OffrePage.serviceCiviqueResults, true, "/solutions/service_civique/search_results?favori=true");
+      OffrePage.serviceCiviqueResults,
+      true,
+      "/solutions/service_civique/search_results?favori=true",
+    );
     assertAnalyticsWidgetName(
-        OffrePage.serviceCiviqueResults, false, "/solutions/service_civique/search_results?favori=false");
+      OffrePage.serviceCiviqueResults,
+      false,
+      "/solutions/service_civique/search_results?favori=false",
+    );
     assertAnalyticsWidgetName(OffrePage.serviceCiviqueDetails, true, "/solutions/service_civique/detail?favori=true");
     assertAnalyticsWidgetName(OffrePage.serviceCiviqueDetails, false, "/solutions/service_civique/detail?favori=false");
 
@@ -39,32 +45,5 @@ void main() {
     assertAnalyticsWidgetName(OffrePage.immersionResults, false, "/solutions/immersion/search_results?favori=false");
     assertAnalyticsWidgetName(OffrePage.immersionDetails, true, "/solutions/immersion/detail?favori=true");
     assertAnalyticsWidgetName(OffrePage.immersionDetails, false, "/solutions/immersion/detail?favori=false");
-  });
-
-  group("getAnalyticsEventName with from", () {
-    void assertAnalyticsEventName(OffrePage from, String? expected) {
-      test("AppPage: $from -> $expected", () {
-        // Given
-        final helper = FavoriHeartAnalyticsHelper();
-        // When
-        final result = helper.getAnalyticsEventName(from);
-        // Then
-        expect(result, expected);
-      });
-    }
-
-    assertAnalyticsEventName(OffrePage.offreFavoris, "favoris/list");
-
-    assertAnalyticsEventName(OffrePage.emploiResults, "recherche/emploi/search_results");
-    assertAnalyticsEventName(OffrePage.emploiDetails, "recherche/emploi/detail");
-
-    assertAnalyticsEventName(OffrePage.alternanceResults, "recherche/alternance/search_results");
-    assertAnalyticsEventName(OffrePage.alternanceDetails, "recherche/alternance/detail");
-
-    assertAnalyticsEventName(OffrePage.serviceCiviqueResults, "recherche/service_civique/search_results");
-    assertAnalyticsEventName(OffrePage.serviceCiviqueDetails, "recherche/service_civique/detail");
-
-    assertAnalyticsEventName(OffrePage.immersionResults, "recherche/immersion/search_results");
-    assertAnalyticsEventName(OffrePage.immersionDetails, "recherche/immersion/detail");
   });
 }


### PR DESCRIPTION
Gros micmac de compréhension de comment fonctionne Matomo.

1. A date, on ne remontait quasiment que des tracking "Widget", parce que le SDK dans la méthode `trackScreen` prenait le context fournit en paramètre, et track un "toString()" dessus…
2. Ensuite, on réalise qu'il y a un champs "event", mais que celui-ci n'apparait jamais dans les Dashboard. Le SDK en a besoin, et il faut qu'il ne soit pas vide. Du coup je repasse le `widgetName` "au cas où"
3. Enfin, pour que les choses apparaissent dans le bon dashboard Matomo comme avant, j'ai du ajouter le `path`, toujours avec la même valeur.

Au final, j'ai arrêté les ambiguïtés à la dure : plus qu'une seule méthode `trackScreen`, qui en vrai appelle le SDK Matomo avec leur méthode `trackScreenWithName`. Mais qui pour le `widgetName`, `widgetName`, le `eventName` et le `path` le seul paramètre que l'on renseigne.