### PR TITLE
fix(1653): Fix different incorrect behaviors on demo mode

### DIFF
--- a/lib/pages/main_page.dart
+++ b/lib/pages/main_page.dart
@@ -25,7 +25,9 @@ import 'package:pass_emploi_app/widgets/buttons/primary_action_button.dart';
 import 'package:pass_emploi_app/widgets/buttons/secondary_button.dart';
 import 'package:pass_emploi_app/widgets/default_app_bar.dart';
 import 'package:pass_emploi_app/widgets/menu_item.dart' as menu;
+import 'package:pass_emploi_app/widgets/pass_emploi_material_app.dart';
 import 'package:pass_emploi_app/widgets/snack_bar/rating_snack_bar.dart';
+import 'package:pass_emploi_app/widgets/snack_bar/show_snack_bar.dart';
 
 class MainPage extends StatefulWidget {
   final MainPageDisplayState displayState;
@@ -203,6 +205,7 @@ class _MainPageState extends State<MainPage> with WidgetsBindingObserver {
 
 class _ModeDemoWrapper extends StatelessWidget {
   final Widget child;
+
   const _ModeDemoWrapper({
     Key? key,
     required this.child,
@@ -215,13 +218,16 @@ class _ModeDemoWrapper extends StatelessWidget {
     if (!isDemo) return child;
     return Scaffold(
       appBar: ModeDemoAppBar(),
-      body: MaterialApp(
+      body: PassEmploiMaterialApp(
+        scaffoldMessengerKey: modeDemoSnackBarKey,
         debugShowCheckedModeBanner: false,
         builder: (context, materialAppChild) => MediaQuery.removePadding(
           context: context,
           removeTop: true,
           child: materialAppChild ?? Container(),
         ),
+        // required to avoid automatic top scrolling when keyboard is displayed
+        useInheritedMediaQuery: true,
         home: child,
       ),
     );

--- a/lib/pages/suggestions_recherche/suggestions_recherche_list_page.dart
+++ b/lib/pages/suggestions_recherche/suggestions_recherche_list_page.dart
@@ -312,7 +312,7 @@ class _CloseSnackbar extends StatelessWidget {
     return InkWell(
       onTap: () {
         viewModel.resetTraiterState();
-        snackbarKey.currentState?.hideCurrentSnackBar();
+        clearAllSnackBars();
       },
       child: Padding(
         padding: const EdgeInsets.fromLTRB(16, 16, 24, 16),
@@ -336,7 +336,7 @@ class _SeeResults extends StatelessWidget {
       onPressed: () {
         viewModel.seeOffreResults();
         viewModel.resetTraiterState();
-        snackbarKey.currentState?.removeCurrentSnackBar();
+        clearAllSnackBars();
       },
       child: Row(
         children: [

--- a/lib/pass_emploi_app.dart
+++ b/lib/pass_emploi_app.dart
@@ -1,11 +1,10 @@
 import 'package:flutter/material.dart';
-import 'package:flutter_localizations/flutter_localizations.dart';
 import 'package:flutter_redux/flutter_redux.dart';
 import 'package:pass_emploi_app/analytics/ignore_tracking_context_provider.dart';
 import 'package:pass_emploi_app/pages/router_page.dart';
 import 'package:pass_emploi_app/redux/app_state.dart';
 import 'package:pass_emploi_app/ui/strings.dart';
-import 'package:pass_emploi_app/ui/theme.dart';
+import 'package:pass_emploi_app/widgets/pass_emploi_material_app.dart';
 import 'package:pass_emploi_app/widgets/snack_bar/show_snack_bar.dart';
 import 'package:redux/redux.dart';
 
@@ -20,21 +19,11 @@ class PassEmploiApp extends StatelessWidget {
     return StoreProvider<AppState>(
       store: _store,
       child: IgnoreTrackingContextProvider(
-        child: MaterialApp(
-          scaffoldMessengerKey: snackbarKey,
+        child: PassEmploiMaterialApp(
+          scaffoldMessengerKey: snackBarKey,
           title: Strings.appName,
-          theme: PassEmploiTheme.data,
-          home: RouterPage(),
           navigatorObservers: [routeObserver],
-          localizationsDelegates: [
-            GlobalMaterialLocalizations.delegate,
-            GlobalWidgetsLocalizations.delegate,
-            GlobalCupertinoLocalizations.delegate,
-          ],
-          supportedLocales: [
-            Locale('en'),
-            Locale('fr'),
-          ],
+          home: RouterPage(),
         ),
       ),
     );

--- a/lib/widgets/pass_emploi_material_app.dart
+++ b/lib/widgets/pass_emploi_material_app.dart
@@ -1,0 +1,51 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_localizations/flutter_localizations.dart';
+import 'package:pass_emploi_app/ui/theme.dart';
+
+class PassEmploiMaterialApp extends MaterialApp{
+  PassEmploiMaterialApp({
+    super.key,
+    super.navigatorKey,
+    super.scaffoldMessengerKey,
+    super.home,
+    super.routes,
+    super.initialRoute,
+    super.onGenerateRoute,
+    super.onGenerateInitialRoutes,
+    super.onUnknownRoute,
+    super.navigatorObservers,
+    super.builder,
+    super.title,
+    super.onGenerateTitle,
+    super.color,
+    super.darkTheme,
+    super.highContrastTheme,
+    super.highContrastDarkTheme,
+    super.themeMode,
+    super.locale,
+    super.localeListResolutionCallback,
+    super.localeResolutionCallback,
+    super.debugShowMaterialGrid,
+    super.showPerformanceOverlay,
+    super.checkerboardRasterCacheImages,
+    super.checkerboardOffscreenLayers,
+    super.showSemanticsDebugger,
+    super.debugShowCheckedModeBanner,
+    super.shortcuts,
+    super.actions,
+    super.restorationScopeId,
+    super.scrollBehavior,
+    super.useInheritedMediaQuery,
+  }) : super(
+    theme: PassEmploiTheme.data,
+    localizationsDelegates: [
+      GlobalMaterialLocalizations.delegate,
+      GlobalWidgetsLocalizations.delegate,
+      GlobalCupertinoLocalizations.delegate,
+    ],
+    supportedLocales: [
+      Locale('en'),
+      Locale('fr'),
+    ],
+  );
+}

--- a/lib/widgets/snack_bar/rating_snack_bar.dart
+++ b/lib/widgets/snack_bar/rating_snack_bar.dart
@@ -53,7 +53,7 @@ class _DismissSnackBar extends StatelessWidget {
 
   void _onDismiss(BuildContext context, RatingViewModel viewModel) {
     viewModel.onDone();
-    snackbarKey.currentState?.hideCurrentSnackBar();
+    clearAllSnackBars();
     PassEmploiMatomoTracker.instance.trackScreen(AnalyticsActionNames.skipRating);
   }
 }
@@ -78,7 +78,7 @@ class _OnRatingTap extends StatelessWidget {
   Widget build(BuildContext context) {
     return InkWell(
       onTap: () {
-        snackbarKey.currentState?.hideCurrentSnackBar();
+        clearAllSnackBars();
         showPassEmploiBottomSheet(context: context, builder: (context) => RatingBottomSheet());
       },
       child: Padding(

--- a/lib/widgets/snack_bar/show_snack_bar.dart
+++ b/lib/widgets/snack_bar/show_snack_bar.dart
@@ -5,7 +5,8 @@ import 'package:pass_emploi_app/ui/margins.dart';
 import 'package:pass_emploi_app/ui/strings.dart';
 import 'package:pass_emploi_app/ui/text_styles.dart';
 
-final GlobalKey<ScaffoldMessengerState> snackbarKey = GlobalKey<ScaffoldMessengerState>();
+final GlobalKey<ScaffoldMessengerState> snackBarKey = GlobalKey<ScaffoldMessengerState>();
+final GlobalKey<ScaffoldMessengerState> modeDemoSnackBarKey = GlobalKey<ScaffoldMessengerState>();
 
 void showSuccessfulSnackBar(BuildContext context, String label, [VoidCallback? onSeeDetailTap]) {
   _showSnackBar(context, label, onSeeDetailTap, success: true);
@@ -16,7 +17,7 @@ void showFailedSnackBar(BuildContext context, String label, [VoidCallback? onSee
 }
 
 void _showSnackBar(BuildContext context, String label, VoidCallback? onSeeDetailTap, {required bool success}) {
-  _clearAllSnackBars();
+  clearAllSnackBars();
   ScaffoldMessenger.of(context).showSnackBar(
     SnackBar(
       padding: EdgeInsets.symmetric(
@@ -42,7 +43,7 @@ void _showSnackBar(BuildContext context, String label, VoidCallback? onSeeDetail
               SizedBox(
                 height: 30,
                 child: IconButton(
-                  onPressed: () => _clearAllSnackBars(),
+                  onPressed: () => clearAllSnackBars(),
                   icon: Icon(
                     Icons.close_rounded,
                     size: 24,
@@ -58,7 +59,7 @@ void _showSnackBar(BuildContext context, String label, VoidCallback? onSeeDetail
               child: TextButton(
                 style: TextButton.styleFrom(padding: EdgeInsets.zero),
                 onPressed: () {
-                  _clearAllSnackBars();
+                  clearAllSnackBars();
                   onSeeDetailTap();
                 },
                 child: Text(Strings.seeDetail, style: TextStyles.textSRegular(color: AppColors.secondary)),
@@ -70,4 +71,7 @@ void _showSnackBar(BuildContext context, String label, VoidCallback? onSeeDetail
   );
 }
 
-void _clearAllSnackBars() => snackbarKey.currentState?.clearSnackBars();
+void clearAllSnackBars() {
+  snackBarKey.currentState?.clearSnackBars();
+  modeDemoSnackBarKey.currentState?.clearSnackBars();
+}


### PR DESCRIPTION
1. Add `useInheritedMediaQuery` to avoid automatic top scrolling when keyboard is displayed.
2. Add `localizationsDelegates` and `supportedLocales` on demo mode MaterialApp, in order to properly displayed components such as `DatePicker`.
3. Create new `modeDemoSnackBarKey` to enable closing of SnackBar even in demo mode.