### PR TITLE
feat(1967): Mise en place du tracking Matomo sur les sessions côté mobile

### DIFF
--- a/lib/analytics/analytics_constants.dart
+++ b/lib/analytics/analytics_constants.dart
@@ -32,22 +32,20 @@ class AnalyticsScreenNames {
   static const searchDemarcheStep3Success = "/demarches/createSuccess";
   static const createDemarchePersonnalisee = "demarches/creer_demarche_personalisee";
   static const thematiquesDemarche = "demarches/thematiques";
+
   static String thematiquesDemarcheDetails(String thematique) => "demarches/thematiques/$thematique";
   static const topDemarches = "demarches/top-demarches";
+
   static String topDemarcheDetails(String demarche) => "demarches/top-demarches/$demarche";
 
   static const rendezvousListPast = "rdv/list-past";
   static const rendezvousListFuture = "rdv/list-future";
   static const rendezvousListWeek = "rdv/list-week-";
-  static const rendezvousActivitesExterieures = "rdv/activites-exterieures";
-  static const rendezvousAtelier = "rdv/atelier";
-  static const rendezvousEntretienIndividuel = "rdv/entretien-individuel";
-  static const rendezvousEntretienPartenaire = "rdv/entretien-partenaire";
-  static const rendezvousInformationCollective = "rdv/information-collective";
-  static const rendezvousVisite = "rdv/visite";
-  static const rendezvousPrestation = "rdv/prestation";
-  static const rendezvousAutre = "rdv/autre";
+  static const rendezvousDetails = "rdv/detail";
+  static const animationCollectiveDetails = "animation_collective/detail";
+  static const sessionMiloDetails = "session_milo/detail";
 
+  static const animationCollectivePartagePageSuccess = "animation_collective/detail?partage-conseiller=true";
   static const sessionMiloPartagePageSuccess = "session_milo/detail?partage-conseiller=true";
 
   static const rechercheV2Home = "recherche/home";
@@ -89,7 +87,6 @@ class AnalyticsScreenNames {
   static const toolbox = "recherche/boite_a_outils";
 
   static const eventList = "events/list";
-  static const eventPartagePageSuccess = "events/detail?partage-conseiller=true";
 
   static const evenementEmploiRecherche = "evenement_emploi";
   static const evenementEmploiDetails = "evenement_emploi/detail";

--- a/lib/pages/rendezvous/rendezvous_details_page.dart
+++ b/lib/pages/rendezvous/rendezvous_details_page.dart
@@ -27,7 +27,7 @@ import 'package:pass_emploi_app/widgets/tags/job_tag.dart';
 import 'package:pass_emploi_app/widgets/text_with_clickable_links.dart';
 import 'package:redux/redux.dart';
 
-class RendezvousDetailsPage extends StatelessWidget {
+class RendezvousDetailsPage extends StatefulWidget {
   final String _rendezvousId;
   final RendezvousStateSource _source;
   final RendezvousDetailsViewModel Function(Store<AppState>) _converter;
@@ -53,33 +53,42 @@ class RendezvousDetailsPage extends StatelessWidget {
   }
 
   @override
+  State<RendezvousDetailsPage> createState() => _RendezvousDetailsPageState();
+}
+
+class _RendezvousDetailsPageState extends State<RendezvousDetailsPage> {
+  bool _hasBeenTracked = false;
+
+  @override
   Widget build(BuildContext context) {
     return StoreConnector<AppState, RendezvousDetailsViewModel>(
       onInit: _onInit,
-      converter: _converter,
+      converter: widget._converter,
       builder: _scaffold,
-      onInitialBuild: (viewModel) {
-        if (viewModel.trackingPageName != null) {
-          PassEmploiMatomoTracker.instance.trackScreen(viewModel.trackingPageName!);
-        }
-      },
       onDispose: (store) {
-        _source == RendezvousStateSource.noSource ? store.dispatch(RendezvousDetailsResetAction()) : {};
-        _source == RendezvousStateSource.sessionMiloDetails ? store.dispatch(SessionMiloDetailsResetAction()) : {};
+        widget._source == RendezvousStateSource.noSource ? store.dispatch(RendezvousDetailsResetAction()) : {};
+        widget._source == RendezvousStateSource.sessionMiloDetails
+            ? store.dispatch(SessionMiloDetailsResetAction())
+            : {};
       },
       distinct: true,
     );
   }
 
   void _onInit(Store<AppState> store) {
-    if (_source == RendezvousStateSource.sessionMiloDetails) {
-      store.dispatch(SessionMiloDetailsRequestAction(_rendezvousId));
-    } else if (_source == RendezvousStateSource.noSource) {
-      store.dispatch(RendezvousDetailsRequestAction(_rendezvousId));
+    if (widget._source == RendezvousStateSource.sessionMiloDetails) {
+      store.dispatch(SessionMiloDetailsRequestAction(widget._rendezvousId));
+    } else if (widget._source == RendezvousStateSource.noSource) {
+      store.dispatch(RendezvousDetailsRequestAction(widget._rendezvousId));
     }
   }
 
   Widget _scaffold(BuildContext context, RendezvousDetailsViewModel viewModel) {
+    // Required here has we need retrieval from state to determine proper tracking page name
+    if (!_hasBeenTracked && viewModel.trackingPageName != null) {
+      PassEmploiMatomoTracker.instance.trackScreen(viewModel.trackingPageName!);
+      _hasBeenTracked = true;
+    }
     const backgroundColor = Colors.white;
     return Scaffold(
       backgroundColor: backgroundColor,

--- a/lib/pages/rendezvous/rendezvous_details_page.dart
+++ b/lib/pages/rendezvous/rendezvous_details_page.dart
@@ -84,11 +84,7 @@ class _RendezvousDetailsPageState extends State<RendezvousDetailsPage> {
   }
 
   Widget _scaffold(BuildContext context, RendezvousDetailsViewModel viewModel) {
-    // Required here has we need retrieval from state to determine proper tracking page name
-    if (!_hasBeenTracked && viewModel.trackingPageName != null) {
-      PassEmploiMatomoTracker.instance.trackScreen(viewModel.trackingPageName!);
-      _hasBeenTracked = true;
-    }
+    _trackPageOnRendezvousRetrievalFromState(viewModel);
     const backgroundColor = Colors.white;
     return Scaffold(
       backgroundColor: backgroundColor,
@@ -145,6 +141,13 @@ class _RendezvousDetailsPageState extends State<RendezvousDetailsPage> {
         ),
       ),
     );
+  }
+
+  void _trackPageOnRendezvousRetrievalFromState(RendezvousDetailsViewModel viewModel) {
+    if (!_hasBeenTracked && viewModel.trackingPageName != null) {
+      PassEmploiMatomoTracker.instance.trackScreen(viewModel.trackingPageName!);
+      _hasBeenTracked = true;
+    }
   }
 }
 

--- a/lib/presentation/chat_partage_page_view_model.dart
+++ b/lib/presentation/chat_partage_page_view_model.dart
@@ -133,7 +133,7 @@ class ChatPartagePageViewModel extends Equatable {
       snackbarState: _snackbarState(store),
       snackbarDisplayed: () => store.dispatch(ChatPartageResetAction()),
       snackbarSuccessText: Strings.partageEventSuccess,
-      snackbarSuccessTracking: AnalyticsScreenNames.eventPartagePageSuccess,
+      snackbarSuccessTracking: AnalyticsScreenNames.animationCollectivePartagePageSuccess,
     );
   }
 

--- a/lib/presentation/rendezvous/rendezvous_details_view_model.dart
+++ b/lib/presentation/rendezvous/rendezvous_details_view_model.dart
@@ -135,7 +135,7 @@ class RendezvousDetailsViewModel extends Equatable {
       visioButtonState: _visioButtonState(rdv),
       visioRedirectUrl: rdv.visioRedirectUrl,
       onRetry: () => {},
-      trackingPageName: _trackingPageName(rdv.type.code),
+      trackingPageName: _trackingPageName(source, rdv.type.code),
       title: rdv.title,
       commentTitle: _commentTitle(source, rdv, comment),
       comment: _comment(source, comment),
@@ -153,10 +153,7 @@ class RendezvousDetailsViewModel extends Equatable {
     RendezvousStateSource source,
     String rdvId,
   ) {
-    final fromSession = [
-      RendezvousStateSource.sessionMiloDetails,
-    ].contains(source);
-    final isFailure = fromSession
+    final isFailure = source.isMiloDetails
         ? store.state.sessionMiloDetailsState is SessionMiloDetailsFailureState
         : store.state.rendezvousDetailsState is RendezvousDetailsFailureState;
     return RendezvousDetailsViewModel(
@@ -177,7 +174,7 @@ class RendezvousDetailsViewModel extends Equatable {
       withIfAbsentPart: false,
       visioButtonState: VisioButtonState.HIDDEN,
       onRetry: () {
-        fromSession
+        source.isMiloDetails
             ? store.dispatch(SessionMiloDetailsRequestAction(rdvId))
             : store.dispatch(RendezvousDetailsRequestAction(rdvId));
       },
@@ -335,25 +332,12 @@ VisioButtonState _visioButtonState(Rendezvous rdv) {
   return VisioButtonState.HIDDEN;
 }
 
-String? _trackingPageName(RendezvousTypeCode code) {
-  switch (code) {
-    case RendezvousTypeCode.ACTIVITE_EXTERIEURES:
-      return AnalyticsScreenNames.rendezvousActivitesExterieures;
-    case RendezvousTypeCode.ATELIER:
-      return AnalyticsScreenNames.rendezvousAtelier;
-    case RendezvousTypeCode.ENTRETIEN_INDIVIDUEL_CONSEILLER:
-      return AnalyticsScreenNames.rendezvousEntretienIndividuel;
-    case RendezvousTypeCode.ENTRETIEN_PARTENAIRE:
-      return AnalyticsScreenNames.rendezvousEntretienPartenaire;
-    case RendezvousTypeCode.INFORMATION_COLLECTIVE:
-      return AnalyticsScreenNames.rendezvousInformationCollective;
-    case RendezvousTypeCode.VISITE:
-      return AnalyticsScreenNames.rendezvousVisite;
-    case RendezvousTypeCode.PRESTATION:
-      return AnalyticsScreenNames.rendezvousPrestation;
-    case RendezvousTypeCode.AUTRE:
-      return AnalyticsScreenNames.rendezvousAutre;
+String? _trackingPageName(RendezvousStateSource source, RendezvousTypeCode type) {
+  if (source.isMiloDetails) return AnalyticsScreenNames.sessionMiloDetails;
+  if ([RendezvousTypeCode.ATELIER, RendezvousTypeCode.INFORMATION_COLLECTIVE].contains(type)) {
+    return AnalyticsScreenNames.animationCollectiveDetails;
   }
+  return AnalyticsScreenNames.rendezvousDetails;
 }
 
 String? _withAnimateur(RendezvousStateSource source, String? animateur) {

--- a/test/presentation/chat_partage_page_view_model_test.dart
+++ b/test/presentation/chat_partage_page_view_model_test.dart
@@ -32,7 +32,7 @@ void main() {
       expect(viewModel.shareButtonTitle, "Partager à mon conseiller");
       expect(viewModel.snackbarSuccessText,
           "L’événement a été partagé à votre conseiller sur la messagerie de l’application");
-      expect(viewModel.snackbarSuccessTracking, "events/detail?partage-conseiller=true");
+      expect(viewModel.snackbarSuccessTracking, "animation_collective/detail?partage-conseiller=true");
     });
 
     test('should partager event', () {

--- a/test/presentation/rendezvous/rendezvous_details_view_model_test.dart
+++ b/test/presentation/rendezvous/rendezvous_details_view_model_test.dart
@@ -841,7 +841,7 @@ void main() {
           isInVisio: false,
           withConseiller: true,
           isAnnule: false,
-          type: RendezvousType(RendezvousTypeCode.ATELIER, 'Atelier'),
+          type: RendezvousType(RendezvousTypeCode.ENTRETIEN_PARTENAIRE, 'Entretien Partenaire'),
           comment: 'comment',
           organism: 'organism',
           address: 'address',
@@ -863,7 +863,7 @@ void main() {
             displayState: DisplayState.CONTENT,
             navbarTitle: "Mon rendez-vous",
             id: "1",
-            tag: "Atelier",
+            tag: "Entretien Partenaire",
             greenTag: false,
             date: '01 mars 2022',
             hourAndDuration: '00:00 (30min)',
@@ -877,7 +877,7 @@ void main() {
             withIfAbsentPart: true,
             visioButtonState: VisioButtonState.HIDDEN,
             onRetry: () => {},
-            trackingPageName: 'rdv/atelier',
+            trackingPageName: 'rdv/detail',
             modality: 'Le rendez-vous se fera sur place : Mission Locale',
             conseiller: 'votre conseiller Nils Tavernier',
             commentTitle: 'Commentaire de mon conseiller',
@@ -966,7 +966,7 @@ void main() {
               onRetry: () => {},
               commentTitle: 'Commentaire',
               title: 'ANIMATION COLLECTIVE POUR TEST - SESSION TEST',
-              trackingPageName: "rdv/atelier",
+              trackingPageName: "session_milo/detail",
               comment: 'Lorem ipsus',
               address: 'Paris',
               addressRedirectUri: Uri.parse('https://maps.apple.com/maps?q=Paris'),
@@ -1073,82 +1073,83 @@ void main() {
     });
   });
 
-  group("tracking should be set correctly depending on rendezvous type", () {
-    void assertTrackingPageName(Rendezvous rdv, String trackingPageName) {
-      test("${rdv.type.code} -> $trackingPageName", () async {
-        // Given
-        final store = _store(rdv);
+  group("tracking when rendezvous…", () {
+    test('source state is Session Milo Details should be track as a Session Milo', () {
+      // Given
+      final store = givenState().loggedInUser().withSuccessSessionMiloDetails().store();
 
-        // When
-        final viewModel = RendezvousDetailsViewModel.create(
-          store: store,
-          source: RendezvousStateSource.rendezvousList,
-          rdvId: '1',
-          platform: Platform.IOS,
-        );
+      // When
+      final viewModel = RendezvousDetailsViewModel.create(
+        store: store,
+        source: RendezvousStateSource.sessionMiloDetails,
+        rdvId: '1',
+        platform: Platform.IOS,
+      );
 
-        // Then
-        expect(viewModel.trackingPageName, trackingPageName);
-      });
-    }
+      // Then
+      expect(viewModel.trackingPageName, 'session_milo/detail');
+    });
 
-    assertTrackingPageName(
-      mockRendezvous(id: '1', type: RendezvousType(RendezvousTypeCode.ACTIVITE_EXTERIEURES, '')),
-      'rdv/activites-exterieures',
-    );
+    test('is of type ATELIER should be track as an Animation Collective', () {
+      // Given
+      final rdv = mockRendezvous(id: '1', type: RendezvousType(RendezvousTypeCode.ATELIER, ''));
+      final store = givenState().loggedInUser().rendezvous(rendezvous: [rdv]).store();
 
-    assertTrackingPageName(
-      mockRendezvous(id: '1', type: RendezvousType(RendezvousTypeCode.ATELIER, '')),
-      'rdv/atelier',
-    );
+      // When
+      final viewModel = RendezvousDetailsViewModel.create(
+        store: store,
+        source: RendezvousStateSource.rendezvousList,
+        rdvId: '1',
+        platform: Platform.IOS,
+      );
 
-    assertTrackingPageName(
-      mockRendezvous(id: '1', type: RendezvousType(RendezvousTypeCode.ENTRETIEN_INDIVIDUEL_CONSEILLER, '')),
-      'rdv/entretien-individuel',
-    );
+      // Then
+      expect(viewModel.trackingPageName, 'animation_collective/detail');
+    });
 
-    assertTrackingPageName(
-      mockRendezvous(id: '1', type: RendezvousType(RendezvousTypeCode.ENTRETIEN_PARTENAIRE, '')),
-      'rdv/entretien-partenaire',
-    );
+    test('is of type INFORMATION_COLLECTIVE should be track as an Animation Collective', () {
+      // Given
+      final rdv = mockRendezvous(id: '1', type: RendezvousType(RendezvousTypeCode.INFORMATION_COLLECTIVE, ''));
+      final store = givenState().loggedInUser().rendezvous(rendezvous: [rdv]).store();
 
-    assertTrackingPageName(
-      mockRendezvous(id: '1', type: RendezvousType(RendezvousTypeCode.INFORMATION_COLLECTIVE, '')),
-      'rdv/information-collective',
-    );
+      // When
+      final viewModel = RendezvousDetailsViewModel.create(
+        store: store,
+        source: RendezvousStateSource.rendezvousList,
+        rdvId: '1',
+        platform: Platform.IOS,
+      );
 
-    assertTrackingPageName(
-      mockRendezvous(id: '1', type: RendezvousType(RendezvousTypeCode.VISITE, '')),
-      'rdv/visite',
-    );
+      // Then
+      expect(viewModel.trackingPageName, 'animation_collective/detail');
+    });
 
-    assertTrackingPageName(
-      mockRendezvous(id: '1', type: RendezvousType(RendezvousTypeCode.PRESTATION, '')),
-      'rdv/prestation',
-    );
+    test('otherwise should be track as a Rendezvous', () {
+      // Given
+      final rdv = mockRendezvous(id: '1', type: RendezvousType(RendezvousTypeCode.ENTRETIEN_INDIVIDUEL_CONSEILLER, ''));
+      final store = givenState().loggedInUser().rendezvous(rendezvous: [rdv]).store();
 
-    assertTrackingPageName(
-      mockRendezvous(id: '1', type: RendezvousType(RendezvousTypeCode.AUTRE, '')),
-      'rdv/autre',
-    );
+      // When
+      final viewModel = RendezvousDetailsViewModel.create(
+        store: store,
+        source: RendezvousStateSource.rendezvousList,
+        rdvId: '1',
+        platform: Platform.IOS,
+      );
+
+      // Then
+      expect(viewModel.trackingPageName, 'rdv/detail');
+    });
   });
 }
 
 Store<AppState> _store(Rendezvous rendezvous) {
-  return TestStoreFactory().initializeReduxStore(
-    initialState: loggedInState().copyWith(
-      rendezvousListState: RendezvousListState.successfulFuture(rendezvous: [rendezvous]),
-    ),
-  );
+  return givenState().loggedInUser().rendezvous(rendezvous: [rendezvous]).store();
 }
 
 Store<AppState> _storeNotUpToDate(Rendezvous rendezvous, DateTime dateDerniereMiseAJour) {
-  return TestStoreFactory().initializeReduxStore(
-    initialState: loggedInState().copyWith(
-      rendezvousListState: RendezvousListState.successfulFuture(
-        rendezvous: [rendezvous],
-        dateDerniereMiseAJour: dateDerniereMiseAJour,
-      ),
-    ),
-  );
+  return givenState()
+      .loggedInUser()
+      .rendezvous(rendezvous: [rendezvous], dateDerniereMiseAJour: dateDerniereMiseAJour) //
+      .store();
 }


### PR DESCRIPTION
Alors, ce que j’ai fait sur cette US

- Quand on est sur la page rendez-vous pour une Session, on track “session_milo/detail“
- Quand on est sur la page rendez-vous pour un RDV de type ATELIER, on track “animation_collective/detail“
- Quand on est sur la page rendez-vous pour un RDV de type INFORMATION_COLLECTIVE, on track “animation_collective/detail“
- Quand on est sur la page rendez-vous pour un RDV d’un autre type , on track “rdv/detail“
- Quand on est sur le partage d’un RDV de type ATELIER ou INFORMATION_COLLECTIVE, on track “animation_collective/detail?partage-conseiller=true“