### PR TITLE
refactor: change 401 logout logic

### DIFF
--- a/lib/auth/auth_access_checker.dart
+++ b/lib/auth/auth_access_checker.dart
@@ -18,9 +18,6 @@ class AuthAccessChecker {
 
 extension _StringExtension on String {
   bool containsExpiredToken() {
-    if (contains("token_pole_emploi_expired")) return true;
-    if (contains("token_milo_expired")) return true;
-    if (contains("auth_user_not_found")) return true;token
-    return false;
+    return contains("token_pole_emploi_expired") || contains("token_milo_expired") || contains("auth_user_not_found");
   }
 }

--- a/lib/auth/auth_access_checker.dart
+++ b/lib/auth/auth_access_checker.dart
@@ -7,7 +7,7 @@ class AuthAccessChecker {
   late Store<AppState> _store;
 
   void logoutUserIfTokenIsExpired(String? message, int statusCode) {
-    if (message?.containsExpiredToken() == true && statusCode == 401) {
+    if (message?.containsExpiredToken() == true || statusCode == 401) {
       Log.i("Logout user on token expired: $message.");
       _store.dispatch(RequestLogoutAction(LogoutReason.apiResponse401));
     }
@@ -20,6 +20,7 @@ extension _StringExtension on String {
   bool containsExpiredToken() {
     if (contains("token_pole_emploi_expired")) return true;
     if (contains("token_milo_expired")) return true;
+    if (contains("auth_user_not_found")) return true;token
     return false;
   }
 }

--- a/test/auth/auth_access_checker_test.dart
+++ b/test/auth/auth_access_checker_test.dart
@@ -28,10 +28,11 @@ void main() {
 
     assertLogout(null, 200, expectLogout: false);
     assertLogout('message', 200, expectLogout: false);
-    assertLogout('token_pole_emploi_expired', 200, expectLogout: false);
-    assertLogout('message', 401, expectLogout: false);
+    assertLogout('token_pole_emploi_expired', 200, expectLogout: true);
+    assertLogout('message', 401, expectLogout: true);
     assertLogout('token_pole_emploi_expired', 401, expectLogout: true);
     assertLogout('token_milo_expired', 401, expectLogout: true);
+    assertLogout('auth_user_not_found', 403, expectLogout: true);
     assertLogout(
       '{"statusCode":401,"message":"Unauthorized","code":"token_pole_emploi_expired"}',
       401,


### PR DESCRIPTION
Ce refacto corrige un ano et rajoute une fonctionnalité :
L'ano : quand la session de l'utilisateur est terminée l'acess token reste valide jusqu'à la fin des 30 minutes de validié (ou 10 min, tu peux vérifier @adgeg stp) ? Sauf que session terminée = aucun token n'est valide => donc l'API répond 401, donc le client doit déco en cas de 401, sans chech le message

La fonctionnalité : déco si le mobile recoit "auth_user_not_found", ce cas arrive lorsque le jeune est archvié et qu'il a toujours une session valide sur l'app, on lui force le logout