### PR TITLE
feat(3028): Module de feedback in-app

### DIFF
--- a/lib/analytics/analytics_constants.dart
+++ b/lib/analytics/analytics_constants.dart
@@ -299,6 +299,13 @@ class AnalyticsEventNames {
   static const a11yWithoutScreenReader = "Sans lecteur d'écran";
   static const a11yWithTextScale = "Avec agrandissement de texte";
   static const a11yWithoutTextScale = "Sans agrandissement de texte";
+
+  static String feedbackCategory(String feature) => "Feedback pour la fonctionnalité : $feature";
+  static const feedback1Action = "Note 1/5";
+  static const feedback2Action = "Note 2/5";
+  static const feedback3Action = "Note 3/5";
+  static const feedback4Action = "Note 4/5";
+  static const feedback5Action = "Note 5/5";
 }
 
 class AnalyticsCustomDimensions {

--- a/lib/app_initializer.dart
+++ b/lib/app_initializer.dart
@@ -70,6 +70,7 @@ import 'package:pass_emploi_app/repositories/favoris/service_civique_favoris_rep
 import 'package:pass_emploi_app/repositories/first_launch_onboarding_repository.dart';
 import 'package:pass_emploi_app/repositories/immersion/immersion_details_repository.dart';
 import 'package:pass_emploi_app/repositories/immersion/immersion_repository.dart';
+import 'package:pass_emploi_app/repositories/in_app_feedback_repository.dart';
 import 'package:pass_emploi_app/repositories/installation_id_repository.dart';
 import 'package:pass_emploi_app/repositories/matching_demarche_repository.dart';
 import 'package:pass_emploi_app/repositories/metier_repository.dart';
@@ -296,6 +297,7 @@ class AppInitializer {
       MatchingDemarcheRepository(thematiqueDemarcheRepository),
       DateConsultationOffreRepository(securedPreferences),
       DerniereOffreConsulteeRepository(securedPreferences),
+      InAppFeedbackRepository(securedPreferences, remoteConfigRepository),
       /*AUTOGENERATE-REDUX-APP-INITIALIZER-REPOSITORY-CONSTRUCTOR*/
     ).initializeReduxStore(initialState: AppState.initialState(configuration: configuration));
     accessTokenRetriever.setStore(reduxStore);

--- a/lib/features/in_app_feedback/in_app_feedback_actions.dart
+++ b/lib/features/in_app_feedback/in_app_feedback_actions.dart
@@ -1,0 +1,17 @@
+class InAppFeedbackRequestAction {
+  final String feature;
+
+  InAppFeedbackRequestAction(this.feature);
+}
+
+class InAppFeedbackDismissAction {
+  final String feature;
+
+  InAppFeedbackDismissAction(this.feature);
+}
+
+class InAppFeedbackSuccessAction {
+  final MapEntry<String, bool> feedbackActivationForFeature;
+
+  InAppFeedbackSuccessAction(this.feedbackActivationForFeature);
+}

--- a/lib/features/in_app_feedback/in_app_feedback_middleware.dart
+++ b/lib/features/in_app_feedback/in_app_feedback_middleware.dart
@@ -1,0 +1,24 @@
+import 'package:pass_emploi_app/features/in_app_feedback/in_app_feedback_actions.dart';
+import 'package:pass_emploi_app/redux/app_state.dart';
+import 'package:pass_emploi_app/repositories/in_app_feedback_repository.dart';
+import 'package:redux/redux.dart';
+
+class InAppFeedbackMiddleware extends MiddlewareClass<AppState> {
+  final InAppFeedbackRepository _repository;
+
+  InAppFeedbackMiddleware(this._repository);
+
+  @override
+  void call(Store<AppState> store, action, NextDispatcher next) async {
+    next(action);
+    if (action is InAppFeedbackRequestAction) {
+      final activation = await _repository.isFeedbackActivated(action.feature);
+      store.dispatch(InAppFeedbackSuccessAction(MapEntry(action.feature, activation)));
+    }
+
+    if (action is InAppFeedbackDismissAction) {
+      await _repository.dismissFeedback(action.feature);
+      store.dispatch(InAppFeedbackSuccessAction(MapEntry(action.feature, false)));
+    }
+  }
+}

--- a/lib/features/in_app_feedback/in_app_feedback_reducer.dart
+++ b/lib/features/in_app_feedback/in_app_feedback_reducer.dart
@@ -1,0 +1,16 @@
+import 'package:pass_emploi_app/features/in_app_feedback/in_app_feedback_actions.dart';
+import 'package:pass_emploi_app/features/in_app_feedback/in_app_feedback_state.dart';
+
+InAppFeedbackState inAppFeedbackReducer(InAppFeedbackState current, dynamic action) {
+  if (action is InAppFeedbackSuccessAction) {
+    final copy = Map<String, bool>.from(current.feedbackActivationForFeatures);
+    copy[action.feedbackActivationForFeature.key] = action.feedbackActivationForFeature.value;
+    return InAppFeedbackState(feedbackActivationForFeatures: copy);
+  }
+  if (action is InAppFeedbackDismissAction) {
+    final copy = Map<String, bool>.from(current.feedbackActivationForFeatures);
+    copy[action.feature] = false;
+    return InAppFeedbackState(feedbackActivationForFeatures: copy);
+  }
+  return current;
+}

--- a/lib/features/in_app_feedback/in_app_feedback_state.dart
+++ b/lib/features/in_app_feedback/in_app_feedback_state.dart
@@ -1,0 +1,10 @@
+import 'package:equatable/equatable.dart';
+
+class InAppFeedbackState extends Equatable {
+  final Map<String, bool> feedbackActivationForFeatures;
+
+  InAppFeedbackState({this.feedbackActivationForFeatures = const {}});
+
+  @override
+  List<Object?> get props => [feedbackActivationForFeatures];
+}

--- a/lib/models/feedback_for_feature.dart
+++ b/lib/models/feedback_for_feature.dart
@@ -1,0 +1,13 @@
+class FeedbackForFeature {
+  final int displayAfter;
+  final DateTime until;
+
+  FeedbackForFeature(this.displayAfter, this.until);
+
+  factory FeedbackForFeature.fromJson(dynamic json) {
+    return FeedbackForFeature(
+      json['displayAfter'] as int,
+      DateTime.parse(json['until'] as String),
+    );
+  }
+}

--- a/lib/pages/offre_emploi/offre_emploi_details_page.dart
+++ b/lib/pages/offre_emploi/offre_emploi_details_page.dart
@@ -34,6 +34,7 @@ import 'package:pass_emploi_app/widgets/external_link.dart';
 import 'package:pass_emploi_app/widgets/favori_heart.dart';
 import 'package:pass_emploi_app/widgets/favori_state_selector.dart';
 import 'package:pass_emploi_app/widgets/help_tooltip.dart';
+import 'package:pass_emploi_app/widgets/in_app_feedback.dart';
 import 'package:pass_emploi_app/widgets/offre_emploi_origin.dart';
 import 'package:pass_emploi_app/widgets/sepline.dart';
 import 'package:pass_emploi_app/widgets/tags/data_tag.dart';
@@ -122,6 +123,11 @@ class OffreEmploiDetailsPage extends StatelessWidget {
             child: Column(
               crossAxisAlignment: CrossAxisAlignment.start,
               children: [
+                InAppFeedback(
+                  feature: 'provenance-offre',
+                  label: Strings.feedbackProvenanceOffre,
+                  padding: const EdgeInsets.only(bottom: Margins.spacing_m),
+                ),
                 if (id != null) Text(Strings.offreDetailNumber(id), style: TextStyles.textXsRegular()),
                 if (lastUpdate != null)
                   Padding(

--- a/lib/pages/offre_emploi/offre_emploi_details_page.dart
+++ b/lib/pages/offre_emploi/offre_emploi_details_page.dart
@@ -123,11 +123,6 @@ class OffreEmploiDetailsPage extends StatelessWidget {
             child: Column(
               crossAxisAlignment: CrossAxisAlignment.start,
               children: [
-                InAppFeedback(
-                  feature: 'provenance-offre',
-                  label: Strings.feedbackProvenanceOffre,
-                  padding: const EdgeInsets.only(bottom: Margins.spacing_m),
-                ),
                 if (id != null) Text(Strings.offreDetailNumber(id), style: TextStyles.textXsRegular()),
                 if (lastUpdate != null)
                   Padding(
@@ -139,6 +134,11 @@ class OffreEmploiDetailsPage extends StatelessWidget {
                   ),
                 SizedBox(height: Margins.spacing_s),
                 if (viewModel.originViewModel != null) ...[
+                  InAppFeedback(
+                    feature: 'provenance-offre',
+                    label: Strings.feedbackProvenanceOffre,
+                    padding: const EdgeInsets.only(top: Margins.spacing_s, bottom: Margins.spacing_m),
+                  ),
                   OffreEmploiOrigin(
                     label: viewModel.originViewModel!.name,
                     source: viewModel.originViewModel!.source,

--- a/lib/pages/profil/profil_page.dart
+++ b/lib/pages/profil/profil_page.dart
@@ -30,6 +30,7 @@ import 'package:pass_emploi_app/widgets/cards/generic/card_container.dart';
 import 'package:pass_emploi_app/widgets/cards/profil/mon_conseiller_card.dart';
 import 'package:pass_emploi_app/widgets/contact_page.dart';
 import 'package:pass_emploi_app/widgets/default_app_bar.dart';
+import 'package:pass_emploi_app/widgets/in_app_feedback.dart';
 import 'package:pass_emploi_app/widgets/pressed_tip.dart';
 import 'package:pass_emploi_app/widgets/rating_page.dart';
 import 'package:pass_emploi_app/widgets/snack_bar/show_snack_bar.dart';
@@ -73,6 +74,13 @@ class _Scaffold extends StatelessWidget {
             child: Column(
               crossAxisAlignment: CrossAxisAlignment.stretch,
               children: [
+                // TODO(22-11-2024): Remove after PO review
+                InAppFeedback(
+                  feature: 'raclette',
+                  label: "Manger une raclette 🧀 avec mes collègues sur ma pause déjeuner me rend heureux.",
+                  backgroundColor: Colors.white,
+                  padding: EdgeInsets.only(bottom: Margins.spacing_base),
+                ),
                 _UsernameTitle(userName: viewModel.userName, onTitleTap: viewModel.onTitleTap),
                 SizedBox(height: Margins.spacing_base),
                 if (viewModel.withCje) ...[

--- a/lib/redux/app_reducer.dart
+++ b/lib/redux/app_reducer.dart
@@ -14,10 +14,12 @@ import 'package:pass_emploi_app/features/connectivity/connectivity_reducer.dart'
 import 'package:pass_emploi_app/features/contact_immersion/contact_immersion_reducer.dart';
 import 'package:pass_emploi_app/features/cv/cv_reducer.dart';
 import 'package:pass_emploi_app/features/cvm/cvm_reducer.dart';
+import 'package:pass_emploi_app/features/date_consultation_offre/date_consultation_offre_reducer.dart';
 import 'package:pass_emploi_app/features/deep_link/deep_link_reducer.dart';
 import 'package:pass_emploi_app/features/demarche/create/create_demarche_reducer.dart';
 import 'package:pass_emploi_app/features/demarche/search/seach_demarche_reducer.dart';
 import 'package:pass_emploi_app/features/demarche/update/update_demarche_reducer.dart';
+import 'package:pass_emploi_app/features/derniere_offre_consultee/derniere_offre_consultee_reducer.dart';
 import 'package:pass_emploi_app/features/details_jeune/details_jeune_reducer.dart';
 import 'package:pass_emploi_app/features/developer_option/activation/developer_options_reducer.dart';
 import 'package:pass_emploi_app/features/developer_option/matomo/matomo_logging_reducer.dart';
@@ -30,6 +32,7 @@ import 'package:pass_emploi_app/features/favori/update/favori_update_reducer.dar
 import 'package:pass_emploi_app/features/feature_flip/feature_flip_reducer.dart';
 import 'package:pass_emploi_app/features/first_launch_onboarding/first_launch_onboarding_reducer.dart';
 import 'package:pass_emploi_app/features/immersion/details/immersion_details_reducer.dart';
+import 'package:pass_emploi_app/features/in_app_feedback/in_app_feedback_reducer.dart';
 import 'package:pass_emploi_app/features/location/search_location_reducer.dart';
 import 'package:pass_emploi_app/features/login/login_actions.dart';
 import 'package:pass_emploi_app/features/login/login_reducer.dart';
@@ -77,8 +80,6 @@ import 'package:pass_emploi_app/models/immersion.dart';
 import 'package:pass_emploi_app/models/offre_emploi.dart';
 import 'package:pass_emploi_app/models/service_civique.dart';
 import 'package:pass_emploi_app/redux/app_state.dart';
-import 'package:pass_emploi_app/features/date_consultation_offre/date_consultation_offre_reducer.dart';
-import 'package:pass_emploi_app/features/derniere_offre_consultee/derniere_offre_consultee_reducer.dart';
 /*AUTOGENERATE-REDUX-APP-REDUCER-IMPORT*/
 
 AppState reducer(AppState current, dynamic action) {
@@ -189,6 +190,7 @@ AppState reducer(AppState current, dynamic action) {
     cguState: cguReducer(current.cguState, action),
     dateConsultationOffreState: dateConsultationOffreReducer(current.dateConsultationOffreState, action),
     derniereOffreConsulteeState: derniereOffreConsulteeReducer(current.derniereOffreConsulteeState, action),
+    inAppFeedbackState: inAppFeedbackReducer(current.inAppFeedbackState, action),
     /*AUTOGENERATE-REDUX-APP-REDUCER-STATE*/
   );
 }

--- a/lib/redux/app_state.dart
+++ b/lib/redux/app_state.dart
@@ -35,6 +35,7 @@ import 'package:pass_emploi_app/features/favori/update/favori_update_state.dart'
 import 'package:pass_emploi_app/features/feature_flip/feature_flip_state.dart';
 import 'package:pass_emploi_app/features/first_launch_onboarding/first_launch_onboarding_state.dart';
 import 'package:pass_emploi_app/features/immersion/details/immersion_details_state.dart';
+import 'package:pass_emploi_app/features/in_app_feedback/in_app_feedback_state.dart';
 import 'package:pass_emploi_app/features/location/search_location_state.dart';
 import 'package:pass_emploi_app/features/login/login_state.dart';
 import 'package:pass_emploi_app/features/matching_demarche/matching_demarche_state.dart';
@@ -149,6 +150,7 @@ class AppState extends Equatable {
   final CguState cguState;
   final DateConsultationOffreState dateConsultationOffreState;
   final DerniereOffreConsulteeState derniereOffreConsulteeState;
+  final InAppFeedbackState inAppFeedbackState;
   /*AUTOGENERATE-REDUX-APP-STATE-PROPERTY*/
 
   AppState({
@@ -224,6 +226,7 @@ class AppState extends Equatable {
     required this.cguState,
     required this.dateConsultationOffreState,
     required this.derniereOffreConsulteeState,
+    required this.inAppFeedbackState,
     /*AUTOGENERATE-REDUX-APP-STATE-CONSTRUCTOR*/
   });
 
@@ -300,6 +303,7 @@ class AppState extends Equatable {
     final CguState? cguState,
     final DateConsultationOffreState? dateConsultationOffreState,
     final DerniereOffreConsulteeState? derniereOffreConsulteeState,
+    final InAppFeedbackState? inAppFeedbackState,
     /*AUTOGENERATE-REDUX-APP-STATE-COPYPARAM*/
   }) {
     return AppState(
@@ -375,6 +379,7 @@ class AppState extends Equatable {
       cguState: cguState ?? this.cguState,
       dateConsultationOffreState: dateConsultationOffreState ?? this.dateConsultationOffreState,
       derniereOffreConsulteeState: derniereOffreConsulteeState ?? this.derniereOffreConsulteeState,
+      inAppFeedbackState: inAppFeedbackState ?? this.inAppFeedbackState,
       /*AUTOGENERATE-REDUX-APP-STATE-COPYBODY*/
     );
   }
@@ -453,6 +458,7 @@ class AppState extends Equatable {
       cguState: CguNotInitializedState(),
       dateConsultationOffreState: DateConsultationOffreState(),
       derniereOffreConsulteeState: DerniereOffreConsulteeState(),
+      inAppFeedbackState: InAppFeedbackState(),
       /*AUTOGENERATE-REDUX-APP-STATE-FACTORY*/
     );
   }
@@ -524,6 +530,7 @@ class AppState extends Equatable {
         cguState,
         dateConsultationOffreState,
         derniereOffreConsulteeState,
+        inAppFeedbackState,
         /*AUTOGENERATE-REDUX-APP-STATE-EQUATABLE*/
       ];
 

--- a/lib/redux/store_factory.dart
+++ b/lib/redux/store_factory.dart
@@ -25,9 +25,11 @@ import 'package:pass_emploi_app/features/connectivity/connectivity_middleware.da
 import 'package:pass_emploi_app/features/contact_immersion/contact_immersion_middleware.dart';
 import 'package:pass_emploi_app/features/cv/cv_middleware.dart';
 import 'package:pass_emploi_app/features/cvm/cvm_middleware.dart';
+import 'package:pass_emploi_app/features/date_consultation_offre/date_consultation_offre_middleware.dart';
 import 'package:pass_emploi_app/features/demarche/create/create_demarche_middleware.dart';
 import 'package:pass_emploi_app/features/demarche/search/seach_demarche_middleware.dart';
 import 'package:pass_emploi_app/features/demarche/update/update_demarche_middleware.dart';
+import 'package:pass_emploi_app/features/derniere_offre_consultee/derniere_offre_consultee_middleware.dart';
 import 'package:pass_emploi_app/features/details_jeune/details_jeune_middleware.dart';
 import 'package:pass_emploi_app/features/developer_option/activation/developer_options_middleware.dart';
 import 'package:pass_emploi_app/features/developer_option/matomo/matomo_logging_middleware.dart';
@@ -41,6 +43,7 @@ import 'package:pass_emploi_app/features/favori/update/favori_update_middleware.
 import 'package:pass_emploi_app/features/feature_flip/feature_flip_middleware.dart';
 import 'package:pass_emploi_app/features/first_launch_onboarding/first_launch_onboarding_middleware.dart';
 import 'package:pass_emploi_app/features/immersion/details/immersion_details_middleware.dart';
+import 'package:pass_emploi_app/features/in_app_feedback/in_app_feedback_middleware.dart';
 import 'package:pass_emploi_app/features/location/search_location_middleware.dart';
 import 'package:pass_emploi_app/features/login/login_middleware.dart';
 import 'package:pass_emploi_app/features/matching_demarche/matching_demarche_middleware.dart';
@@ -80,8 +83,6 @@ import 'package:pass_emploi_app/features/user_action/create/user_action_create_m
 import 'package:pass_emploi_app/features/user_action/delete/user_action_delete_middleware.dart';
 import 'package:pass_emploi_app/features/user_action/details/user_action_details_middleware.dart';
 import 'package:pass_emploi_app/features/user_action/update/user_action_update_middleware.dart';
-import 'package:pass_emploi_app/features/date_consultation_offre/date_consultation_offre_middleware.dart';
-import 'package:pass_emploi_app/features/derniere_offre_consultee/derniere_offre_consultee_middleware.dart';
 /*AUTOGENERATE-REDUX-STOREFACTORY-IMPORT-MIDDLEWARE*/
 import 'package:pass_emploi_app/models/immersion.dart';
 import 'package:pass_emploi_app/models/offre_emploi.dart';
@@ -110,9 +111,11 @@ import 'package:pass_emploi_app/repositories/cv_repository.dart';
 import 'package:pass_emploi_app/repositories/cvm/cvm_alerting_repository.dart';
 import 'package:pass_emploi_app/repositories/cvm/cvm_bridge.dart';
 import 'package:pass_emploi_app/repositories/cvm/cvm_token_repository.dart';
+import 'package:pass_emploi_app/repositories/date_consultation_offre_repository.dart';
 import 'package:pass_emploi_app/repositories/demarche/create_demarche_repository.dart';
 import 'package:pass_emploi_app/repositories/demarche/search_demarche_repository.dart';
 import 'package:pass_emploi_app/repositories/demarche/update_demarche_repository.dart';
+import 'package:pass_emploi_app/repositories/derniere_offre_consultee_repository.dart';
 import 'package:pass_emploi_app/repositories/details_jeune/details_jeune_repository.dart';
 import 'package:pass_emploi_app/repositories/developer_option_repository.dart';
 import 'package:pass_emploi_app/repositories/diagoriente_metiers_favoris_repository.dart';
@@ -127,6 +130,7 @@ import 'package:pass_emploi_app/repositories/favoris/service_civique_favoris_rep
 import 'package:pass_emploi_app/repositories/first_launch_onboarding_repository.dart';
 import 'package:pass_emploi_app/repositories/immersion/immersion_details_repository.dart';
 import 'package:pass_emploi_app/repositories/immersion/immersion_repository.dart';
+import 'package:pass_emploi_app/repositories/in_app_feedback_repository.dart';
 import 'package:pass_emploi_app/repositories/matching_demarche_repository.dart';
 import 'package:pass_emploi_app/repositories/metier_repository.dart';
 import 'package:pass_emploi_app/repositories/mon_suivi_repository.dart';
@@ -154,8 +158,6 @@ import 'package:pass_emploi_app/repositories/user_action_repository.dart';
 import 'package:pass_emploi_app/usecases/piece_jointe/piece_jointe_use_case.dart';
 import 'package:pass_emploi_app/utils/pass_emploi_matomo_tracker.dart';
 import 'package:pass_emploi_app/wrappers/connectivity_wrapper.dart';
-import 'package:pass_emploi_app/repositories/date_consultation_offre_repository.dart';
-import 'package:pass_emploi_app/repositories/derniere_offre_consultee_repository.dart';
 /*AUTOGENERATE-REDUX-STOREFACTORY-IMPORT-REPOSITORY*/
 import 'package:redux/redux.dart' as redux;
 
@@ -231,9 +233,9 @@ class StoreFactory {
   final FirstLaunchOnboardingRepository firstLaunchOnboardingRepository;
   final PieceJointeUseCase pieceJointeUseCase;
   final MatchingDemarcheRepository matchingDemarcheRepository;
-
   final DateConsultationOffreRepository dateConsultationOffreRepository;
   final DerniereOffreConsulteeRepository derniereOffreConsulteeRepository;
+  final InAppFeedbackRepository inAppFeedbackRepository;
   /*AUTOGENERATE-REDUX-STOREFACTORY-PROPERTY-REPOSITORY*/
 
   StoreFactory(
@@ -310,6 +312,7 @@ class StoreFactory {
     this.matchingDemarcheRepository,
     this.dateConsultationOffreRepository,
     this.derniereOffreConsulteeRepository,
+    this.inAppFeedbackRepository,
     /*AUTOGENERATE-REDUX-STOREFACTORY-CONSTRUCTOR-REPOSITORY*/
   );
 
@@ -405,6 +408,7 @@ class StoreFactory {
         CguMiddleware(detailsJeuneRepository, remoteConfigRepository).call,
         DateConsultationOffreMiddleware(dateConsultationOffreRepository).call,
         DerniereOffreConsulteeMiddleware(derniereOffreConsulteeRepository).call,
+        InAppFeedbackMiddleware(inAppFeedbackRepository).call,
         /*AUTOGENERATE-REDUX-STOREFACTORY-ADD-MIDDLEWARE*/
         ..._debugMiddlewares(),
         ..._stagingMiddlewares(initialState.configurationState.getFlavor()),

--- a/lib/repositories/in_app_feedback_repository.dart
+++ b/lib/repositories/in_app_feedback_repository.dart
@@ -1,0 +1,31 @@
+import 'package:clock/clock.dart';
+import 'package:flutter_secure_storage/flutter_secure_storage.dart';
+import 'package:pass_emploi_app/repositories/remote_config_repository.dart';
+
+class InAppFeedbackRepository {
+  final FlutterSecureStorage _secureStorage;
+  final RemoteConfigRepository _remoteConfigRepository;
+
+  InAppFeedbackRepository(this._secureStorage, this._remoteConfigRepository);
+
+  Future<bool> isFeedbackActivated(String feature) async {
+    final inAppFeedbackForFeature = _remoteConfigRepository.inAppFeedbackForFeature(feature);
+    if (inAppFeedbackForFeature == null) return false;
+    if (clock.now().isAfter(inAppFeedbackForFeature.until)) return false;
+    final displayCount = await _incrementDisplayCount(feature);
+    return displayCount >= inAppFeedbackForFeature.displayAfter;
+  }
+
+  Future<void> dismissFeedback(String feature) async {
+    await _secureStorage.write(key: _key(feature), value: '-100000');
+  }
+
+  Future<int> _incrementDisplayCount(String feature) async {
+    final displayCount = await _secureStorage.read(key: _key(feature)) ?? '0';
+    final displayCountIncremented = int.parse(displayCount) + 1;
+    await _secureStorage.write(key: _key(feature), value: displayCountIncremented.toString());
+    return displayCountIncremented;
+  }
+
+  String _key(String feature) => 'display-count-for-feature-$feature';
+}

--- a/lib/repositories/remote_config_repository.dart
+++ b/lib/repositories/remote_config_repository.dart
@@ -3,6 +3,7 @@ import 'dart:convert';
 import 'package:firebase_remote_config/firebase_remote_config.dart';
 import 'package:pass_emploi_app/models/accompagnement.dart';
 import 'package:pass_emploi_app/models/cgu.dart';
+import 'package:pass_emploi_app/models/feedback_for_feature.dart';
 
 class RemoteConfigRepository {
   final FirebaseRemoteConfig? _firebaseRemoteConfig;
@@ -59,5 +60,15 @@ class RemoteConfigRepository {
     // Despite Remote config documentation, Firebase returns "null" string value when key is not found
     if (cguAsString.isEmpty || cguAsString == "null") return null;
     return Cgu.fromJson(json.decode(cguAsString));
+  }
+
+  FeedbackForFeature? inAppFeedbackForFeature(String feature) {
+    if (_firebaseRemoteConfig == null) return null;
+    final String inAppFeedbackAsString = _firebaseRemoteConfig.getString('in_app_feedback_for_feature');
+    // Despite Remote config documentation, Firebase returns "null" string value when key is not found
+    if (inAppFeedbackAsString.isEmpty || inAppFeedbackAsString == "null") return null;
+    final inAppFeedbackAsJson = json.decode(inAppFeedbackAsString);
+    final feedbackForFeatureAsJson = inAppFeedbackAsJson[feature];
+    return feedbackForFeatureAsJson != null ? FeedbackForFeature.fromJson(feedbackForFeatureAsJson) : null;
   }
 }

--- a/lib/ui/animation_durations.dart
+++ b/lib/ui/animation_durations.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/material.dart';
 
 class AnimationDurations {
+  static const Duration extraLong = Durations.extralong3;
   static const Duration verySlow = Durations.long2;
   static const Duration slow = Durations.medium4;
   static const Duration medium = Durations.medium2;

--- a/lib/ui/app_icons.dart
+++ b/lib/ui/app_icons.dart
@@ -73,6 +73,12 @@ class AppIcons {
   static const IconData hotel_class = Icons.hotel_class_outlined;
   static const IconData warning_rounded = Icons.warning_rounded;
   static const IconData visibility_outlined = Icons.visibility_outlined;
+  static const IconData help = Icons.help;
+  static const IconData mood_bad = Icons.mood_bad;
+  static const IconData sentiment_dissatisfied = Icons.sentiment_dissatisfied;
+  static const IconData sentiment_neutral = Icons.sentiment_neutral;
+  static const IconData sentiment_satisfied = Icons.sentiment_satisfied;
+  static const IconData mood = Icons.mood;
 
   // Solution
   static const IconData immersion = AppIconsAdditional.immersion;

--- a/lib/ui/strings.dart
+++ b/lib/ui/strings.dart
@@ -1019,7 +1019,9 @@ class Strings {
   // Offre emploi details
   static String offreDetailsError = "Erreur lors de la récupération de l'offre";
   static String offreDetailsTitle = "Détail de l'offre";
+
   static String offreLastSeen(DateTime date) => "Vue le ${date.toDay()}";
+
   static String offreLastSeenA11y(DateTime date) => "Vue le ${date.toDay().toDateForScreenReaders()}";
   static String profileTitle = "Profil souhaité";
   static String experienceTitle = "Expérience";
@@ -1428,6 +1430,13 @@ class Strings {
 
   static String cguSwitchLabel(bool accepted) => accepted ? "Refuser les cgu" : "Accepter les cgu";
 
+  // In-app feedback
+  static String feedbackBad = "Pas d’accord";
+  static String feedbackNeutral = "Neutre";
+  static String feedbackGood = "D’accord";
+  static String feedbackThanks = "Merci pour votre retour !";
+  static String feedbackProvenanceOffre = "Connaître la source d’une offre ([Provenance], etc) m’intéresse.";
+
   // a11y
   static String selectedRadioButton = "Sélectionné";
   static String unselectedRadioButton = "Non sélectionné";
@@ -1479,6 +1488,11 @@ class Strings {
   static String buttonRole = "bouton";
   static String bottomSheetBarrierLabel = "$closeDialog, $buttonRole";
   static String source = "Source : ";
+  static const String moodBad = "Emoticone pas d’accord du tout";
+  static const String sentimentDissatisfied = "Emoticone plutôt pas d’accord";
+  static const String sentimentNeutral = "Emoticone neutre";
+  static const String sentimentSatisfied = "Emoticone plutôt d’accord";
+  static const String mood = "Emoticone d’accord";
 
   static String removeDistance(int value) => 'Diminuer la distance de $value km';
 

--- a/lib/widgets/in_app_feedback.dart
+++ b/lib/widgets/in_app_feedback.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_redux/flutter_redux.dart';
+import 'package:pass_emploi_app/analytics/analytics_constants.dart';
 import 'package:pass_emploi_app/features/in_app_feedback/in_app_feedback_actions.dart';
 import 'package:pass_emploi_app/redux/app_state.dart';
 import 'package:pass_emploi_app/ui/animation_durations.dart';
@@ -9,33 +10,34 @@ import 'package:pass_emploi_app/ui/dimens.dart';
 import 'package:pass_emploi_app/ui/margins.dart';
 import 'package:pass_emploi_app/ui/strings.dart';
 import 'package:pass_emploi_app/ui/text_styles.dart';
+import 'package:pass_emploi_app/utils/context_extensions.dart';
+import 'package:pass_emploi_app/utils/pass_emploi_matomo_tracker.dart';
 
-// TODO Set proper analytics events
 enum _Feedback {
   moodBad(
     icon: AppIcons.mood_bad,
     semantics: Strings.moodBad,
-    analyticsEvent: Strings.moodBad,
+    analyticsEvent: AnalyticsEventNames.feedback1Action,
   ),
   sentimentDissatisfied(
     icon: AppIcons.sentiment_dissatisfied,
     semantics: Strings.sentimentDissatisfied,
-    analyticsEvent: Strings.sentimentDissatisfied,
+    analyticsEvent: AnalyticsEventNames.feedback2Action,
   ),
   sentimentNeutral(
     icon: AppIcons.sentiment_neutral,
     semantics: Strings.sentimentNeutral,
-    analyticsEvent: Strings.sentimentNeutral,
+    analyticsEvent: AnalyticsEventNames.feedback3Action,
   ),
   sentimentSatisfied(
     icon: AppIcons.sentiment_satisfied,
     semantics: Strings.sentimentSatisfied,
-    analyticsEvent: Strings.sentimentSatisfied,
+    analyticsEvent: AnalyticsEventNames.feedback4Action,
   ),
   mood(
     icon: AppIcons.mood,
     semantics: Strings.mood,
-    analyticsEvent: Strings.mood,
+    analyticsEvent: AnalyticsEventNames.feedback5Action,
   );
 
   final IconData icon;
@@ -138,8 +140,11 @@ class _InAppFeedbackWidgetState extends State<_InAppFeedbackWidget> {
                       _FeedbackOptionsGroup(
                         onOptionTap: (feedback) {
                           setState(() => state = _WidgetState.thanks);
-                          // TODO: send analytics event
-                          // TODO: dispatch action to close feedback
+                          PassEmploiMatomoTracker.instance.trackEvent(
+                            eventCategory: AnalyticsEventNames.feedbackCategory(widget.feature),
+                            action: feedback.analyticsEvent,
+                          );
+                          context.dispatch(InAppFeedbackDismissAction(widget.feature));
                         },
                       ),
                       SizedBox(height: 12),
@@ -150,7 +155,7 @@ class _InAppFeedbackWidgetState extends State<_InAppFeedbackWidget> {
                 ),
                 _CloseButton(onPressed: () {
                   setState(() => state = _WidgetState.closed);
-                  // TODO: dispatch action to close feedback
+                  context.dispatch(InAppFeedbackDismissAction(widget.feature));
                 })
               ],
             ),

--- a/lib/widgets/in_app_feedback.dart
+++ b/lib/widgets/in_app_feedback.dart
@@ -14,27 +14,27 @@ import 'package:pass_emploi_app/utils/context_extensions.dart';
 import 'package:pass_emploi_app/utils/pass_emploi_matomo_tracker.dart';
 
 enum _Feedback {
-  moodBad(
+  feedback1(
     icon: AppIcons.mood_bad,
     semantics: Strings.moodBad,
     analyticsEvent: AnalyticsEventNames.feedback1Action,
   ),
-  sentimentDissatisfied(
+  feedback2(
     icon: AppIcons.sentiment_dissatisfied,
     semantics: Strings.sentimentDissatisfied,
     analyticsEvent: AnalyticsEventNames.feedback2Action,
   ),
-  sentimentNeutral(
+  feedback3(
     icon: AppIcons.sentiment_neutral,
     semantics: Strings.sentimentNeutral,
     analyticsEvent: AnalyticsEventNames.feedback3Action,
   ),
-  sentimentSatisfied(
+  feedback4(
     icon: AppIcons.sentiment_satisfied,
     semantics: Strings.sentimentSatisfied,
     analyticsEvent: AnalyticsEventNames.feedback4Action,
   ),
-  mood(
+  feedback5(
     icon: AppIcons.mood,
     semantics: Strings.mood,
     analyticsEvent: AnalyticsEventNames.feedback5Action,
@@ -94,7 +94,7 @@ class _InAppFeedbackState extends State<InAppFeedback> with TickerProviderStateM
   Widget build(BuildContext context) {
     return StoreConnector<AppState, bool>(
       onInit: (store) => store.dispatch(InAppFeedbackRequestAction(widget.feature)),
-      rebuildOnChange: false, // to avoid animation are stopped when state changes
+      rebuildOnChange: false, // later layout changes are made via stateful widget
       converter: (store) => store.state.inAppFeedbackState.feedbackActivationForFeatures[widget.feature] ?? false,
       builder: _builder,
     );
@@ -187,7 +187,7 @@ class _InAppFeedbackWidgetState extends State<_InAppFeedbackWidget> {
               onPressed: () => setState(() => state = _WidgetState.closed),
             ),
           ),
-        _WidgetState.closed => SizedBox.shrink(key: ValueKey<int>(2)),
+        _WidgetState.closed => SizedBox.shrink(),
       },
     );
   }
@@ -228,29 +228,29 @@ class _FeedbackOptionsGroup extends StatelessWidget {
         mainAxisAlignment: MainAxisAlignment.spaceBetween,
         children: [
           _FeedbackOption(
-            feedback: _Feedback.moodBad,
+            feedback: _Feedback.feedback1,
             backgroundColor: backgroundColor,
-            onTap: () => onOptionTap(_Feedback.moodBad),
+            onTap: () => onOptionTap(_Feedback.feedback1),
           ),
           _FeedbackOption(
-            feedback: _Feedback.sentimentDissatisfied,
+            feedback: _Feedback.feedback2,
             backgroundColor: backgroundColor,
-            onTap: () => onOptionTap(_Feedback.sentimentDissatisfied),
+            onTap: () => onOptionTap(_Feedback.feedback2),
           ),
           _FeedbackOption(
-            feedback: _Feedback.sentimentNeutral,
+            feedback: _Feedback.feedback3,
             backgroundColor: backgroundColor,
-            onTap: () => onOptionTap(_Feedback.sentimentNeutral),
+            onTap: () => onOptionTap(_Feedback.feedback3),
           ),
           _FeedbackOption(
-            feedback: _Feedback.sentimentSatisfied,
+            feedback: _Feedback.feedback4,
             backgroundColor: backgroundColor,
-            onTap: () => onOptionTap(_Feedback.sentimentSatisfied),
+            onTap: () => onOptionTap(_Feedback.feedback4),
           ),
           _FeedbackOption(
-            feedback: _Feedback.mood,
+            feedback: _Feedback.feedback5,
             backgroundColor: backgroundColor,
-            onTap: () => onOptionTap(_Feedback.mood),
+            onTap: () => onOptionTap(_Feedback.feedback5),
           ),
         ],
       ),

--- a/lib/widgets/in_app_feedback.dart
+++ b/lib/widgets/in_app_feedback.dart
@@ -8,6 +8,7 @@ import 'package:pass_emploi_app/ui/app_colors.dart';
 import 'package:pass_emploi_app/ui/app_icons.dart';
 import 'package:pass_emploi_app/ui/dimens.dart';
 import 'package:pass_emploi_app/ui/margins.dart';
+import 'package:pass_emploi_app/ui/media_sizes.dart';
 import 'package:pass_emploi_app/ui/strings.dart';
 import 'package:pass_emploi_app/ui/text_styles.dart';
 import 'package:pass_emploi_app/utils/context_extensions.dart';
@@ -306,7 +307,7 @@ class _FeedbackOption extends StatelessWidget {
 class _FeedbackCaption extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
-    const maxWidthForLargeTextScale = 100.0;
+    final maxWidthForLargeTextScale = MediaQuery.of(context).size.width < MediaSizes.width_s ? 60.0 : 100.0;
     return Stack(
       children: [
         Align(

--- a/lib/widgets/in_app_feedback.dart
+++ b/lib/widgets/in_app_feedback.dart
@@ -57,8 +57,14 @@ class InAppFeedback extends StatefulWidget {
   final String feature;
   final String label;
   final EdgeInsetsGeometry padding;
+  final Color backgroundColor;
 
-  const InAppFeedback({required this.feature, required this.label, this.padding = EdgeInsets.zero});
+  const InAppFeedback({
+    required this.feature,
+    required this.label,
+    this.padding = EdgeInsets.zero,
+    this.backgroundColor = AppColors.primaryLighten,
+  });
 
   @override
   State<InAppFeedback> createState() => _InAppFeedbackState();
@@ -98,7 +104,12 @@ class _InAppFeedbackState extends State<InAppFeedback> with TickerProviderStateM
     return switch (display) {
       true => AnimatedBuilder(
           animation: _animation,
-          child: _InAppFeedbackWidget(feature: widget.feature, label: widget.label, padding: widget.padding),
+          child: _InAppFeedbackWidget(
+            feature: widget.feature,
+            label: widget.label,
+            padding: widget.padding,
+            backgroundColor: widget.backgroundColor,
+          ),
           builder: (context, child) => Transform.scale(scale: _animation.value, child: child)),
       false => SizedBox.shrink(),
     };
@@ -109,8 +120,14 @@ class _InAppFeedbackWidget extends StatefulWidget {
   final String feature;
   final String label;
   final EdgeInsetsGeometry padding;
+  final Color backgroundColor;
 
-  const _InAppFeedbackWidget({required this.feature, required this.label, required this.padding});
+  const _InAppFeedbackWidget({
+    required this.feature,
+    required this.label,
+    required this.padding,
+    required this.backgroundColor,
+  });
 
   @override
   State<_InAppFeedbackWidget> createState() => _InAppFeedbackWidgetState();
@@ -133,11 +150,13 @@ class _InAppFeedbackWidgetState extends State<_InAppFeedbackWidget> {
             child: Stack(
               children: [
                 _BorderedContainer(
+                  backgroundColor: widget.backgroundColor,
                   child: Column(
                     children: [
                       _Description(icon: AppIcons.help, label: widget.label),
                       SizedBox(height: Margins.spacing_m),
                       _FeedbackOptionsGroup(
+                        backgroundColor: widget.backgroundColor,
                         onOptionTap: (feedback) {
                           setState(() => state = _WidgetState.thanks);
                           PassEmploiMatomoTracker.instance.trackEvent(
@@ -163,7 +182,10 @@ class _InAppFeedbackWidgetState extends State<_InAppFeedbackWidget> {
         _WidgetState.thanks => Padding(
             key: ValueKey<int>(1),
             padding: widget.padding,
-            child: _Thanks(onPressed: () => setState(() => state = _WidgetState.closed)),
+            child: _Thanks(
+              backgroundColor: widget.backgroundColor,
+              onPressed: () => setState(() => state = _WidgetState.closed),
+            ),
           ),
         _WidgetState.closed => SizedBox.shrink(key: ValueKey<int>(2)),
       },
@@ -193,45 +215,59 @@ class _Description extends StatelessWidget {
 }
 
 class _FeedbackOptionsGroup extends StatelessWidget {
+  final Color backgroundColor;
   final Function(_Feedback) onOptionTap;
 
-  const _FeedbackOptionsGroup({required this.onOptionTap});
+  const _FeedbackOptionsGroup({required this.backgroundColor, required this.onOptionTap});
 
   @override
   Widget build(BuildContext context) {
-    return Row(
-      mainAxisAlignment: MainAxisAlignment.spaceBetween,
-      children: [
-        _FeedbackOption(
-          feedback: _Feedback.moodBad,
-          onTap: () => onOptionTap(_Feedback.moodBad),
-        ),
-        _FeedbackOption(
-          feedback: _Feedback.sentimentDissatisfied,
-          onTap: () => onOptionTap(_Feedback.sentimentDissatisfied),
-        ),
-        _FeedbackOption(
-          feedback: _Feedback.sentimentNeutral,
-          onTap: () => onOptionTap(_Feedback.sentimentNeutral),
-        ),
-        _FeedbackOption(
-          feedback: _Feedback.sentimentSatisfied,
-          onTap: () => onOptionTap(_Feedback.sentimentSatisfied),
-        ),
-        _FeedbackOption(
-          feedback: _Feedback.mood,
-          onTap: () => onOptionTap(_Feedback.mood),
-        ),
-      ],
+    return Semantics(
+      container: true,
+      child: Row(
+        mainAxisAlignment: MainAxisAlignment.spaceBetween,
+        children: [
+          _FeedbackOption(
+            feedback: _Feedback.moodBad,
+            backgroundColor: backgroundColor,
+            onTap: () => onOptionTap(_Feedback.moodBad),
+          ),
+          _FeedbackOption(
+            feedback: _Feedback.sentimentDissatisfied,
+            backgroundColor: backgroundColor,
+            onTap: () => onOptionTap(_Feedback.sentimentDissatisfied),
+          ),
+          _FeedbackOption(
+            feedback: _Feedback.sentimentNeutral,
+            backgroundColor: backgroundColor,
+            onTap: () => onOptionTap(_Feedback.sentimentNeutral),
+          ),
+          _FeedbackOption(
+            feedback: _Feedback.sentimentSatisfied,
+            backgroundColor: backgroundColor,
+            onTap: () => onOptionTap(_Feedback.sentimentSatisfied),
+          ),
+          _FeedbackOption(
+            feedback: _Feedback.mood,
+            backgroundColor: backgroundColor,
+            onTap: () => onOptionTap(_Feedback.mood),
+          ),
+        ],
+      ),
     );
   }
 }
 
 class _FeedbackOption extends StatelessWidget {
   final _Feedback feedback;
+  final Color backgroundColor;
   final VoidCallback onTap;
 
-  const _FeedbackOption({required this.feedback, required this.onTap});
+  const _FeedbackOption({
+    required this.feedback,
+    required this.backgroundColor,
+    required this.onTap,
+  });
 
   @override
   Widget build(BuildContext context) {
@@ -240,7 +276,7 @@ class _FeedbackOption extends StatelessWidget {
         label: feedback.semantics,
         button: true,
         child: Material(
-          color: AppColors.primaryLighten,
+          color: backgroundColor,
           clipBehavior: Clip.hardEdge,
           borderRadius: BorderRadius.circular(Dimens.radius_base),
           child: InkWell(
@@ -327,15 +363,17 @@ class _CloseButton extends StatelessWidget {
 }
 
 class _Thanks extends StatelessWidget {
+  final Color backgroundColor;
   final VoidCallback onPressed;
 
-  const _Thanks({required this.onPressed});
+  const _Thanks({required this.backgroundColor, required this.onPressed});
 
   @override
   Widget build(BuildContext context) {
     return Stack(
       children: [
         _BorderedContainer(
+          backgroundColor: backgroundColor,
           child: _Description(icon: AppIcons.check_circle_outline_rounded, label: Strings.feedbackThanks),
         ),
         _CloseButton(onPressed: onPressed),
@@ -346,14 +384,15 @@ class _Thanks extends StatelessWidget {
 
 class _BorderedContainer extends StatelessWidget {
   final Widget child;
+  final Color backgroundColor;
 
-  const _BorderedContainer({required this.child});
+  const _BorderedContainer({required this.child, required this.backgroundColor});
 
   @override
   Widget build(BuildContext context) {
     return DecoratedBox(
       decoration: BoxDecoration(
-        color: AppColors.primaryLighten,
+        color: backgroundColor,
         borderRadius: BorderRadius.circular(Dimens.radius_base),
       ),
       child: Padding(

--- a/lib/widgets/in_app_feedback.dart
+++ b/lib/widgets/in_app_feedback.dart
@@ -1,0 +1,360 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_redux/flutter_redux.dart';
+import 'package:pass_emploi_app/features/in_app_feedback/in_app_feedback_actions.dart';
+import 'package:pass_emploi_app/redux/app_state.dart';
+import 'package:pass_emploi_app/ui/animation_durations.dart';
+import 'package:pass_emploi_app/ui/app_colors.dart';
+import 'package:pass_emploi_app/ui/app_icons.dart';
+import 'package:pass_emploi_app/ui/dimens.dart';
+import 'package:pass_emploi_app/ui/margins.dart';
+import 'package:pass_emploi_app/ui/strings.dart';
+import 'package:pass_emploi_app/ui/text_styles.dart';
+
+// TODO Set proper analytics events
+enum _Feedback {
+  moodBad(
+    icon: AppIcons.mood_bad,
+    semantics: Strings.moodBad,
+    analyticsEvent: Strings.moodBad,
+  ),
+  sentimentDissatisfied(
+    icon: AppIcons.sentiment_dissatisfied,
+    semantics: Strings.sentimentDissatisfied,
+    analyticsEvent: Strings.sentimentDissatisfied,
+  ),
+  sentimentNeutral(
+    icon: AppIcons.sentiment_neutral,
+    semantics: Strings.sentimentNeutral,
+    analyticsEvent: Strings.sentimentNeutral,
+  ),
+  sentimentSatisfied(
+    icon: AppIcons.sentiment_satisfied,
+    semantics: Strings.sentimentSatisfied,
+    analyticsEvent: Strings.sentimentSatisfied,
+  ),
+  mood(
+    icon: AppIcons.mood,
+    semantics: Strings.mood,
+    analyticsEvent: Strings.mood,
+  );
+
+  final IconData icon;
+  final String semantics;
+  final String analyticsEvent;
+
+  const _Feedback({required this.icon, required this.semantics, required this.analyticsEvent});
+}
+
+enum _WidgetState {
+  feedback,
+  thanks,
+  closed,
+}
+
+class InAppFeedback extends StatefulWidget {
+  final String feature;
+  final String label;
+  final EdgeInsetsGeometry padding;
+
+  const InAppFeedback({required this.feature, required this.label, this.padding = EdgeInsets.zero});
+
+  @override
+  State<InAppFeedback> createState() => _InAppFeedbackState();
+}
+
+class _InAppFeedbackState extends State<InAppFeedback> with TickerProviderStateMixin {
+  late final AnimationController _controller;
+  late Animation<double> _animation;
+
+  @override
+  void initState() {
+    super.initState();
+    _controller = AnimationController(
+      duration: AnimationDurations.extraLong,
+      vsync: this,
+    )..forward(from: 0.3);
+    _animation = CurvedAnimation(parent: _controller, curve: Curves.easeInOutBack);
+  }
+
+  @override
+  void dispose() {
+    _controller.dispose();
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return StoreConnector<AppState, bool>(
+      onInit: (store) => store.dispatch(InAppFeedbackRequestAction(widget.feature)),
+      rebuildOnChange: false, // to avoid animation are stopped when state changes
+      converter: (store) => store.state.inAppFeedbackState.feedbackActivationForFeatures[widget.feature] ?? false,
+      builder: _builder,
+    );
+  }
+
+  Widget _builder(BuildContext context, bool display) {
+    return switch (display) {
+      true => AnimatedBuilder(
+          animation: _animation,
+          child: _InAppFeedbackWidget(feature: widget.feature, label: widget.label, padding: widget.padding),
+          builder: (context, child) => Transform.scale(scale: _animation.value, child: child)),
+      false => SizedBox.shrink(),
+    };
+  }
+}
+
+class _InAppFeedbackWidget extends StatefulWidget {
+  final String feature;
+  final String label;
+  final EdgeInsetsGeometry padding;
+
+  const _InAppFeedbackWidget({required this.feature, required this.label, required this.padding});
+
+  @override
+  State<_InAppFeedbackWidget> createState() => _InAppFeedbackWidgetState();
+}
+
+class _InAppFeedbackWidgetState extends State<_InAppFeedbackWidget> {
+  _WidgetState state = _WidgetState.feedback;
+
+  @override
+  Widget build(BuildContext context) {
+    return AnimatedSwitcher(
+      duration: AnimationDurations.fast,
+      switchInCurve: Curves.easeInBack,
+      switchOutCurve: Curves.easeOutBack,
+      transitionBuilder: (child, animation) => SizeTransition(sizeFactor: animation, child: child),
+      child: switch (state) {
+        _WidgetState.feedback => Padding(
+            key: ValueKey<int>(0),
+            padding: widget.padding,
+            child: Stack(
+              children: [
+                _BorderedContainer(
+                  child: Column(
+                    children: [
+                      _Description(icon: AppIcons.help, label: widget.label),
+                      SizedBox(height: Margins.spacing_m),
+                      _FeedbackOptionsGroup(
+                        onOptionTap: (feedback) {
+                          setState(() => state = _WidgetState.thanks);
+                          // TODO: send analytics event
+                          // TODO: dispatch action to close feedback
+                        },
+                      ),
+                      SizedBox(height: 12),
+                      _FeedbackCaption(),
+                      SizedBox(height: Margins.spacing_base),
+                    ],
+                  ),
+                ),
+                _CloseButton(onPressed: () {
+                  setState(() => state = _WidgetState.closed);
+                  // TODO: dispatch action to close feedback
+                })
+              ],
+            ),
+          ),
+        _WidgetState.thanks => Padding(
+            key: ValueKey<int>(1),
+            padding: widget.padding,
+            child: _Thanks(onPressed: () => setState(() => state = _WidgetState.closed)),
+          ),
+        _WidgetState.closed => SizedBox.shrink(key: ValueKey<int>(2)),
+      },
+    );
+  }
+}
+
+class _Description extends StatelessWidget {
+  final IconData icon;
+  final String label;
+
+  const _Description({required this.icon, required this.label});
+
+  @override
+  Widget build(BuildContext context) {
+    return Row(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: [
+        Icon(icon, color: AppColors.primary),
+        SizedBox(width: Margins.spacing_s),
+        Flexible(child: Text(label, style: TextStyles.textSBold)),
+        // Extra margin is added to avoid the close button to be too close to the text
+        SizedBox(width: 30),
+      ],
+    );
+  }
+}
+
+class _FeedbackOptionsGroup extends StatelessWidget {
+  final Function(_Feedback) onOptionTap;
+
+  const _FeedbackOptionsGroup({required this.onOptionTap});
+
+  @override
+  Widget build(BuildContext context) {
+    return Row(
+      mainAxisAlignment: MainAxisAlignment.spaceBetween,
+      children: [
+        _FeedbackOption(
+          feedback: _Feedback.moodBad,
+          onTap: () => onOptionTap(_Feedback.moodBad),
+        ),
+        _FeedbackOption(
+          feedback: _Feedback.sentimentDissatisfied,
+          onTap: () => onOptionTap(_Feedback.sentimentDissatisfied),
+        ),
+        _FeedbackOption(
+          feedback: _Feedback.sentimentNeutral,
+          onTap: () => onOptionTap(_Feedback.sentimentNeutral),
+        ),
+        _FeedbackOption(
+          feedback: _Feedback.sentimentSatisfied,
+          onTap: () => onOptionTap(_Feedback.sentimentSatisfied),
+        ),
+        _FeedbackOption(
+          feedback: _Feedback.mood,
+          onTap: () => onOptionTap(_Feedback.mood),
+        ),
+      ],
+    );
+  }
+}
+
+class _FeedbackOption extends StatelessWidget {
+  final _Feedback feedback;
+  final VoidCallback onTap;
+
+  const _FeedbackOption({required this.feedback, required this.onTap});
+
+  @override
+  Widget build(BuildContext context) {
+    return Focus(
+      child: Semantics(
+        label: feedback.semantics,
+        button: true,
+        child: Material(
+          color: AppColors.primaryLighten,
+          clipBehavior: Clip.hardEdge,
+          borderRadius: BorderRadius.circular(Dimens.radius_base),
+          child: InkWell(
+            splashColor: AppColors.primary,
+            onTap: onTap,
+            child: DecoratedBox(
+              decoration: BoxDecoration(
+                borderRadius: BorderRadius.circular(Dimens.radius_base),
+                border: Border.all(color: AppColors.primary),
+              ),
+              child: Padding(
+                padding: const EdgeInsets.symmetric(horizontal: Margins.spacing_s, vertical: Margins.spacing_base),
+                child: Icon(
+                  feedback.icon,
+                  color: AppColors.primary,
+                  size: 32,
+                ),
+              ),
+            ),
+          ),
+        ),
+      ),
+    );
+  }
+}
+
+class _FeedbackCaption extends StatelessWidget {
+  @override
+  Widget build(BuildContext context) {
+    const maxWidthForLargeTextScale = 100.0;
+    return Stack(
+      children: [
+        Align(
+          alignment: Alignment.topLeft,
+          child: SizedBox(
+            width: maxWidthForLargeTextScale,
+            child: Text(Strings.feedbackBad, style: TextStyles.textSMedium(color: AppColors.grey800)),
+          ),
+        ),
+        Align(
+          alignment: Alignment.topCenter,
+          child: SizedBox(
+            width: maxWidthForLargeTextScale,
+            child: Align(
+              alignment: Alignment.topCenter,
+              child: Text(Strings.feedbackNeutral, style: TextStyles.textSMedium(color: AppColors.grey800)),
+            ),
+          ),
+        ),
+        Align(
+          alignment: Alignment.topRight,
+          child: SizedBox(
+            width: maxWidthForLargeTextScale,
+            child: Align(
+              alignment: Alignment.topRight,
+              child: Text(Strings.feedbackGood, style: TextStyles.textSMedium(color: AppColors.grey800)),
+            ),
+          ),
+        ),
+      ],
+    );
+  }
+}
+
+class _CloseButton extends StatelessWidget {
+  final VoidCallback onPressed;
+
+  const _CloseButton({required this.onPressed});
+
+  @override
+  Widget build(BuildContext context) {
+    return Align(
+      alignment: Alignment.topRight,
+      child: Padding(
+        padding: const EdgeInsets.all(Margins.spacing_xs),
+        child: IconButton(
+          icon: Icon(AppIcons.close_rounded),
+          tooltip: Strings.close,
+          onPressed: onPressed,
+        ),
+      ),
+    );
+  }
+}
+
+class _Thanks extends StatelessWidget {
+  final VoidCallback onPressed;
+
+  const _Thanks({required this.onPressed});
+
+  @override
+  Widget build(BuildContext context) {
+    return Stack(
+      children: [
+        _BorderedContainer(
+          child: _Description(icon: AppIcons.check_circle_outline_rounded, label: Strings.feedbackThanks),
+        ),
+        _CloseButton(onPressed: onPressed),
+      ],
+    );
+  }
+}
+
+class _BorderedContainer extends StatelessWidget {
+  final Widget child;
+
+  const _BorderedContainer({required this.child});
+
+  @override
+  Widget build(BuildContext context) {
+    return DecoratedBox(
+      decoration: BoxDecoration(
+        color: AppColors.primaryLighten,
+        borderRadius: BorderRadius.circular(Dimens.radius_base),
+      ),
+      child: Padding(
+        padding: const EdgeInsets.all(Margins.spacing_base),
+        child: child,
+      ),
+    );
+  }
+}

--- a/test/doubles/mocks.dart
+++ b/test/doubles/mocks.dart
@@ -21,6 +21,7 @@ import 'package:pass_emploi_app/repositories/evenement_engagement/evenement_enga
 import 'package:pass_emploi_app/repositories/favoris/get_favoris_repository.dart';
 import 'package:pass_emploi_app/repositories/first_launch_onboarding_repository.dart';
 import 'package:pass_emploi_app/repositories/immersion/immersion_details_repository.dart';
+import 'package:pass_emploi_app/repositories/in_app_feedback_repository.dart';
 import 'package:pass_emploi_app/repositories/matching_demarche_repository.dart';
 import 'package:pass_emploi_app/repositories/mon_suivi_repository.dart';
 import 'package:pass_emploi_app/repositories/offre_emploi/offre_emploi_details_repository.dart';
@@ -263,4 +264,6 @@ class MockDerniereOffreConsulteeRepository extends Mock implements DerniereOffre
     when(() => set(any())).thenAnswer((_) async {});
   }
 }
+
+class MockInAppFeedbackRepository extends Mock implements InAppFeedbackRepository {}
 /*AUTOGENERATE-REDUX-TEST-MOCKS-REPOSITORY-DECLARATION*/

--- a/test/doubles/spies.dart
+++ b/test/doubles/spies.dart
@@ -40,6 +40,7 @@ class StoreSpy extends Store<AppState> {
 class FlutterSecureStorageSpy extends FlutterSecureStorage {
   final Duration delay;
   final Map<String, String> _storedValues = {};
+
   void reset() => _storedValues.clear();
 
   FlutterSecureStorageSpy({this.delay = const Duration(milliseconds: 10)});
@@ -55,7 +56,7 @@ class FlutterSecureStorageSpy extends FlutterSecureStorage {
     MacOsOptions? mOptions,
     WindowsOptions? wOptions,
   }) async {
-    await simulateIoOperation();
+    if (delay != Duration.zero) await simulateIoOperation();
     _storedValues[key] = value!;
   }
 
@@ -69,7 +70,7 @@ class FlutterSecureStorageSpy extends FlutterSecureStorage {
     MacOsOptions? mOptions,
     WindowsOptions? wOptions,
   }) async {
-    await simulateIoOperation();
+    if (delay != Duration.zero) await simulateIoOperation();
     return _storedValues[key];
   }
 
@@ -83,7 +84,7 @@ class FlutterSecureStorageSpy extends FlutterSecureStorage {
     MacOsOptions? mOptions,
     WindowsOptions? wOptions,
   }) async {
-    await simulateIoOperation();
+    if (delay != Duration.zero) await simulateIoOperation();
     _storedValues.remove(key);
   }
 
@@ -96,7 +97,7 @@ class FlutterSecureStorageSpy extends FlutterSecureStorage {
     MacOsOptions? mOptions,
     WindowsOptions? wOptions,
   }) async {
-    await simulateIoOperation();
+    if (delay != Duration.zero) await simulateIoOperation();
     return _storedValues;
   }
 

--- a/test/features/in_app_feedback/in_app_feedback_test.dart
+++ b/test/features/in_app_feedback/in_app_feedback_test.dart
@@ -1,0 +1,64 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mocktail/mocktail.dart';
+import 'package:pass_emploi_app/features/in_app_feedback/in_app_feedback_actions.dart';
+import 'package:pass_emploi_app/features/in_app_feedback/in_app_feedback_state.dart';
+
+import '../../doubles/mocks.dart';
+import '../../dsl/app_state_dsl.dart';
+import '../../dsl/matchers.dart';
+import '../../dsl/sut_redux.dart';
+
+void main() {
+  group('InAppFeedback', () {
+    final sut = StoreSut();
+    final repository = MockInAppFeedbackRepository();
+
+    group("when requesting for feature", () {
+      sut.whenDispatchingAction(() => InAppFeedbackRequestAction('feature-1'));
+
+      test('and feedback activated', () {
+        when(() => repository.isFeedbackActivated('feature-1')).thenAnswer((_) async => true);
+
+        sut.givenStore = givenState().store((f) => {f.inAppFeedbackRepository = repository});
+
+        sut.thenExpectChangingStatesThroughOrder([
+          _expectedResult('feature-1', null),
+          _expectedResult('feature-1', true),
+        ]);
+      });
+
+      test('and feedback not activated', () {
+        when(() => repository.isFeedbackActivated('feature-1')).thenAnswer((_) async => false);
+
+        sut.givenStore = givenState().store((f) => {f.inAppFeedbackRepository = repository});
+
+        sut.thenExpectChangingStatesThroughOrder([
+          _expectedResult('feature-1', null),
+          _expectedResult('feature-1', false),
+        ]);
+      });
+    });
+
+    group("when dismissing for feature", () {
+      sut.whenDispatchingAction(() => InAppFeedbackDismissAction('feature-1'));
+
+      test('should update state and call repository', () {
+        when(() => repository.dismissFeedback('feature-1')).thenAnswer((_) async {});
+
+        sut.givenStore = givenState()
+            .copyWith(inAppFeedbackState: InAppFeedbackState(feedbackActivationForFeatures: {'feature-1': true}))
+            .store((f) => {f.inAppFeedbackRepository = repository});
+
+        sut.thenExpectChangingStatesThroughOrder([_expectedResult('feature-1', false)]);
+        verify(() => repository.dismissFeedback('feature-1')).called(1);
+      });
+    });
+  });
+}
+
+Matcher _expectedResult(String feature, bool? expected) {
+  return StateIs<InAppFeedbackState>(
+    (state) => state.inAppFeedbackState,
+    (state) => expect(state.feedbackActivationForFeatures[feature], expected),
+  );
+}

--- a/test/repositories/in_app_feedback_repository_test.dart
+++ b/test/repositories/in_app_feedback_repository_test.dart
@@ -1,0 +1,105 @@
+import 'package:clock/clock.dart';
+import 'package:flutter_secure_storage/flutter_secure_storage.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mocktail/mocktail.dart';
+import 'package:pass_emploi_app/models/feedback_for_feature.dart';
+import 'package:pass_emploi_app/repositories/in_app_feedback_repository.dart';
+
+import '../doubles/mocks.dart';
+import '../doubles/spies.dart';
+
+void main() {
+  late FlutterSecureStorageSpy secureStorage;
+  late MockRemoteConfigRepository remoteConfigRepository;
+  late InAppFeedbackRepository repository;
+
+  setUp(() {
+    // Because of strange issue in withClock method of clock package, we cannot add a delay to the spy
+    // https://github.com/dart-lang/tools/issues/699
+    secureStorage = FlutterSecureStorageSpy(delay: Duration.zero);
+    remoteConfigRepository = MockRemoteConfigRepository();
+    repository = InAppFeedbackRepository(secureStorage, remoteConfigRepository);
+  });
+
+  group('InAppFeedbackRepository', () {
+    group('isFeedbackActivated', () {
+      test('if absent from remote configuration should return false', () async {
+        // Given
+        when(() => remoteConfigRepository.inAppFeedbackForFeature('feature-1')).thenReturn(null);
+
+        // When
+        final result = await repository.isFeedbackActivated('feature-1');
+
+        // Then
+        expect(result, isFalse);
+      });
+
+      test('if present from remote configuration but campaign is past should return false', () {
+        final now = DateTime(2024, 1, 3);
+        withClock(Clock.fixed(now), () async {
+          // Given
+          when(() => remoteConfigRepository.inAppFeedbackForFeature('feature-1'))
+              .thenReturn(FeedbackForFeature(0, DateTime(2024, 1, 1)));
+
+          // When
+          final result = await repository.isFeedbackActivated('feature-1');
+
+          // Then
+          expect(result, isFalse);
+        });
+      });
+
+      test('if present from remote configuration, campaign is in progress, but not enough display should return false',
+          () {
+        final now = DateTime(2024, 1, 3);
+        withClock(Clock.fixed(now), () async {
+          // Given
+          await _givenFeatureDisplayed(secureStorage, 'feature-1', 1);
+          when(() => remoteConfigRepository.inAppFeedbackForFeature('feature-1'))
+              .thenReturn(FeedbackForFeature(3, DateTime(2024, 1, 4)));
+
+          // When
+          final result = await repository.isFeedbackActivated('feature-1');
+
+          // Then
+          expect(result, isFalse);
+        });
+      });
+
+      test('if present from remote configuration, campaign is in progress, and enough display should return true', () {
+        final now = DateTime(2024, 1, 3);
+        withClock(Clock.fixed(now), () async {
+          // Given
+          await _givenFeatureDisplayed(secureStorage, 'feature-1', 3);
+          when(() => remoteConfigRepository.inAppFeedbackForFeature('feature-1'))
+              .thenReturn(FeedbackForFeature(2, DateTime(2024, 1, 4)));
+
+          // When
+          final result = await repository.isFeedbackActivated('feature-1');
+
+          // Then
+          expect(result, isTrue);
+        });
+      });
+    });
+
+    group('dismissFeedback', () {
+      test('should store an unreachable display count to disable feedback activation', () async {
+        // Given
+        await _givenFeatureDisplayed(secureStorage, 'feature-1', 3);
+        await repository.dismissFeedback('feature-1');
+
+        // When
+        final result = await secureStorage.read(key: 'display-count-for-feature-feature-1');
+
+        // Then
+        expect(result, isNotNull);
+        expect(int.parse(result!), lessThan(-10000));
+      });
+    });
+  });
+}
+
+Future<void> _givenFeatureDisplayed(FlutterSecureStorage secureStorage, String feature, int display) async {
+  await secureStorage.write(key: 'display-count-for-feature-$feature', value: display.toString());
+}

--- a/test/utils/test_setup.dart
+++ b/test/utils/test_setup.dart
@@ -27,9 +27,11 @@ import 'package:pass_emploi_app/repositories/cv_repository.dart';
 import 'package:pass_emploi_app/repositories/cvm/cvm_alerting_repository.dart';
 import 'package:pass_emploi_app/repositories/cvm/cvm_bridge.dart';
 import 'package:pass_emploi_app/repositories/cvm/cvm_token_repository.dart';
+import 'package:pass_emploi_app/repositories/date_consultation_offre_repository.dart';
 import 'package:pass_emploi_app/repositories/demarche/create_demarche_repository.dart';
 import 'package:pass_emploi_app/repositories/demarche/search_demarche_repository.dart';
 import 'package:pass_emploi_app/repositories/demarche/update_demarche_repository.dart';
+import 'package:pass_emploi_app/repositories/derniere_offre_consultee_repository.dart';
 import 'package:pass_emploi_app/repositories/details_jeune/details_jeune_repository.dart';
 import 'package:pass_emploi_app/repositories/developer_option_repository.dart';
 import 'package:pass_emploi_app/repositories/diagoriente_metiers_favoris_repository.dart';
@@ -44,6 +46,7 @@ import 'package:pass_emploi_app/repositories/favoris/service_civique_favoris_rep
 import 'package:pass_emploi_app/repositories/first_launch_onboarding_repository.dart';
 import 'package:pass_emploi_app/repositories/immersion/immersion_details_repository.dart';
 import 'package:pass_emploi_app/repositories/immersion/immersion_repository.dart';
+import 'package:pass_emploi_app/repositories/in_app_feedback_repository.dart';
 import 'package:pass_emploi_app/repositories/matching_demarche_repository.dart';
 import 'package:pass_emploi_app/repositories/metier_repository.dart';
 import 'package:pass_emploi_app/repositories/mon_suivi_repository.dart';
@@ -71,8 +74,6 @@ import 'package:pass_emploi_app/repositories/user_action_repository.dart';
 import 'package:pass_emploi_app/usecases/piece_jointe/piece_jointe_use_case.dart';
 import 'package:pass_emploi_app/utils/pass_emploi_matomo_tracker.dart';
 import 'package:pass_emploi_app/wrappers/connectivity_wrapper.dart';
-import 'package:pass_emploi_app/repositories/date_consultation_offre_repository.dart';
-import 'package:pass_emploi_app/repositories/derniere_offre_consultee_repository.dart';
 /*AUTOGENERATE-REDUX-TEST-SETUP-REPOSITORY-IMPORT*/
 import 'package:redux/redux.dart';
 
@@ -152,9 +153,9 @@ class TestStoreFactory {
   FirstLaunchOnboardingRepository firstLaunchOnboardingRepository = MockFirstLaunchOnboardingRepository();
   PieceJointeUseCase pieceJointeUseCase = MockPieceJointeUseCase();
   MatchingDemarcheRepository matchingDemarcheRepository = MockMatchingDemarcheRepository();
-
   DateConsultationOffreRepository dateConsultationOffreRepository = MockDateConsultationOffreRepository();
   DerniereOffreConsulteeRepository derniereOffreConsulteeRepository = MockDerniereOffreConsulteeRepository();
+  InAppFeedbackRepository inAppFeedbackRepository = MockInAppFeedbackRepository();
   /*AUTOGENERATE-REDUX-TEST-SETUP-REPOSITORY-PROPERTY*/
 
   Store<AppState> initializeReduxStore({required AppState initialState}) {
@@ -232,6 +233,7 @@ class TestStoreFactory {
       matchingDemarcheRepository,
       dateConsultationOffreRepository,
       derniereOffreConsulteeRepository,
+      inAppFeedbackRepository,
       /*AUTOGENERATE-REDUX-TEST-SETUP-REPOSITORY-CONSTRUCTOR*/
     ).initializeReduxStore(initialState: initialState);
   }


### PR DESCRIPTION
Gros kif sur cette PR 😎
C'était assurément celle-ci la vraie dernière ❤️.

Les campagnes sont pilotées via RemoteConfig avec un objet JSON comme celui-ci :
```
{
  "provenance-offre": {
    "displayAfter": 0,
    "until": "2024-12-15"
  },
  "feature-2": {
    "displayAfter": 3,
    "until": "2024-12-05"
  }
}
```

Après, dans l'app il n'y a plus qu'à faire l'appel ci-dessous:
```
InAppFeedback(
    feature: 'feature-2',
    label: 'La feature 2 me plaît beaucoup.',
)

```
et c'est censé marché tout seul 🎉 . Dans cet exemple, au bout de plus de 3 affichage de la page qui contient le `InAppFeedback` pour la feature-2, celui-ci sera affiché. Dès lors que l'on est avant le 5 décembre. Et si l'utilisateur vote ou qu'il ferme le widget, il ne le verra plus. Après, tout remonte dans un événement matomo :

<img width="591" alt="Capture d’écran 2024-11-22 à 02 17 48" src="https://github.com/user-attachments/assets/c2c78798-2d69-4991-981a-6129d1bfe37c">

En ce qui concerne vraiment la PR : il y a pas mal de logique dans la boucle Redux à relire. Et beaucoup de code dans le fichier `in_app_feedback.dart` > **attention il est trop gros et apparait fermé dans la PR**, mais j'aimerai bien que tu le check (pas mal d'anim tout ça).

Merci !!!
